### PR TITLE
7902660: jdis includes unnecessary Field references in MethodHandle parameters while printing static parameters of a bsm and skips the method tag in ldc instructions

### DIFF
--- a/src/org/openjdk/asmtools/jdis/CodeData.java
+++ b/src/org/openjdk/asmtools/jdis/CodeData.java
@@ -520,9 +520,21 @@ public class CodeData extends Indenter {
                         out.print(" BOGUS TYPE:" + type);
                 }
                 return 2;
-            case opc_anewarray:
             case opc_ldc_w:
-            case opc_ldc2_w:
+            case opc_ldc2_w: {
+                // added printing of the tag: Method/Interface to clarify
+                // interpreting CONSTANT_MethodHandle_info:reference_kind
+                // Example: ldc_w Dynamic REF_invokeStatic:Method CondyIndy.condy_bsm
+                cls.pool.setPrintTAG(true);
+                int index = getUShort(pc + 1);
+                if (pr_cpx) {
+                    out.print("\t#" + index + "; //");
+                }
+                PrintConstant(index);
+                cls.pool.setPrintTAG(false);
+                return 3;
+            }
+            case opc_anewarray:
             case opc_instanceof:
             case opc_checkcast:
             case opc_new:
@@ -547,11 +559,16 @@ public class CodeData extends Indenter {
                 out.print("\t" + getbyte(pc + 1));
                 return 2;
             case opc_ldc: {
+                // added printing of the tag: Method/Interface to clarify
+                // interpreting CONSTANT_MethodHandle_info:reference_kind
+                // Example: ldc Dynamic REF_invokeStatic:Method CondyIndy.condy_bsm
+                cls.pool.setPrintTAG(true);
                 int index = getUbyte(pc + 1);
                 if (pr_cpx) {
                     out.print("\t#" + index + "; //");
                 }
                 PrintConstant(index);
+                cls.pool.setPrintTAG(false);
                 return 2;
             }
             case opc_invokeinterface: {

--- a/src/org/openjdk/asmtools/jdis/ConstantPool.java
+++ b/src/org/openjdk/asmtools/jdis/ConstantPool.java
@@ -522,8 +522,15 @@ public class ConstantPool {
             String str = "UnknownTag";
             switch (tag) {
                 case CONSTANT_FIELD:
+                    // CODETOOLS-7902660: the tag Field is not necessary while printing static parameters of a bsm
+                    // Example: MethodHandle REF_getField:ClassName.FieldName:"I"
+                    str = getShortClassName(getClassName(value1), cd.pkgPrefix) + "." + StringValue(value2);
+                    break;
                 case CONSTANT_METHOD:
                 case CONSTANT_INTERFACEMETHOD:
+                    // CODETOOLS-7902648: added printing of the tag: Method/Interface to clarify
+                    // interpreting CONSTANT_MethodHandle_info:reference_kind
+                    // Example: invokedynamic	InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap
                     str = getPrintedTAG(tag) + getShortClassName(getClassName(value1), cd.pkgPrefix) + "." + StringValue(value2);
                     break;
                 case CONSTANT_NAMEANDTYPE:


### PR DESCRIPTION
This is the fix for https://bugs.openjdk.java.net/browse/CODETOOLS-7902660.
The print formats were changed for ldc instructions and static parameters of bs methods.
The previous format was:
ldc Dynamic REF_invokeStatic:CondyIndy.condy_bsm
{
  MethodHandle REF_getField:Field TestRecord01p01.x:"I", 
}
The new format is:
ldc Dynamic REF_invokeStatic:Method CondyIndy.condy_bsm
{
  MethodHandle REF_getField:TestRecord01p01.x:"I",
}
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902660](https://bugs.openjdk.java.net/browse/CODETOOLS-7902660): jdis includes unnecessary Field references in MethodHandle parameters while printing static params of a bsm and skips the method tag in ldc* instructions


### Download
`$ git fetch https://git.openjdk.java.net/asmtools pull/1/head:pull/1`
`$ git checkout pull/1`
