### PR TITLE
7902659: Correct unconditional call of System.exit in printVersion (Main.java)

### DIFF
--- a/src/org/openjdk/asmtools/Main.java
+++ b/src/org/openjdk/asmtools/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,11 +82,10 @@ public class Main {
     }
 
     /**
-     * Prints the tools version and calls System.exit(0)
+     * Prints the tools version
      */
     public static void printVersion() {
-        System.err.println(ProductInfo.FULL_VERSION);
-        System.exit(0);
+        System.out.println(ProductInfo.FULL_VERSION);
     }
 
     /**

--- a/src/org/openjdk/asmtools/jdis/CodeData.java
+++ b/src/org/openjdk/asmtools/jdis/CodeData.java
@@ -520,9 +520,21 @@ public class CodeData extends Indenter {
                         out.print(" BOGUS TYPE:" + type);
                 }
                 return 2;
-            case opc_anewarray:
             case opc_ldc_w:
-            case opc_ldc2_w:
+            case opc_ldc2_w: {
+                // added printing of the tag: Method/Interface to clarify
+                // interpreting CONSTANT_MethodHandle_info:reference_kind
+                // Example: ldc_w Dynamic REF_invokeStatic:Method CondyIndy.condy_bsm
+                cls.pool.setPrintTAG(true);
+                int index = getUShort(pc + 1);
+                if (pr_cpx) {
+                    out.print("\t#" + index + "; //");
+                }
+                PrintConstant(index);
+                cls.pool.setPrintTAG(false);
+                return 3;
+            }
+            case opc_anewarray:
             case opc_instanceof:
             case opc_checkcast:
             case opc_new:
@@ -547,11 +559,16 @@ public class CodeData extends Indenter {
                 out.print("\t" + getbyte(pc + 1));
                 return 2;
             case opc_ldc: {
+                // added printing of the tag: Method/Interface to clarify
+                // interpreting CONSTANT_MethodHandle_info:reference_kind
+                // Example: ldc Dynamic REF_invokeStatic:Method CondyIndy.condy_bsm
+                cls.pool.setPrintTAG(true);
                 int index = getUbyte(pc + 1);
                 if (pr_cpx) {
                     out.print("\t#" + index + "; //");
                 }
                 PrintConstant(index);
+                cls.pool.setPrintTAG(false);
                 return 2;
             }
             case opc_invokeinterface: {

--- a/src/org/openjdk/asmtools/jdis/ConstantPool.java
+++ b/src/org/openjdk/asmtools/jdis/ConstantPool.java
@@ -522,8 +522,15 @@ public class ConstantPool {
             String str = "UnknownTag";
             switch (tag) {
                 case CONSTANT_FIELD:
+                    // CODETOOLS-7902660: the tag Field is not necessary while printing static parameters of a bsm
+                    // Example: MethodHandle REF_getField:ClassName.FieldName:"I"
+                    str = getShortClassName(getClassName(value1), cd.pkgPrefix) + "." + StringValue(value2);
+                    break;
                 case CONSTANT_METHOD:
                 case CONSTANT_INTERFACEMETHOD:
+                    // CODETOOLS-7902648: added printing of the tag: Method/Interface to clarify
+                    // interpreting CONSTANT_MethodHandle_info:reference_kind
+                    // Example: invokedynamic InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap
                     str = getPrintedTAG(tag) + getShortClassName(getClassName(value1), cd.pkgPrefix) + "." + StringValue(value2);
                     break;
                 case CONSTANT_NAMEANDTYPE:


### PR DESCRIPTION
The simple fix for https://bugs.openjdk.java.net/browse/CODETOOLS-7902659
removes the unconditional call System.exit from the method Main::printVersion
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902659](https://bugs.openjdk.java.net/browse/CODETOOLS-7902659): Correct unconditional call of System.exit in printVersion (Main.java)


### Download
`$ git fetch https://git.openjdk.java.net/asmtools pull/3/head:pull/3`
`$ git checkout pull/3`
