### PR TITLE
Repeated calls to setRank cause an error.

### DIFF
--- a/src/org/openjdk/asmtools/jasm/CodeAttr.java
+++ b/src/org/openjdk/asmtools/jasm/CodeAttr.java
@@ -345,7 +345,8 @@ class CodeAttr extends AttrData {
                 break;
             default:
                 if (arg instanceof ConstantPool.ConstCell) {
-                    ((ConstantPool.ConstCell) arg).setRank(1);
+                    if (((ConstantPool.ConstCell) arg).getRank() != 0)
+                        ((ConstantPool.ConstCell) arg).setRank(1);
                 }
         }
         if (env.debugInfoFlag) {

--- a/src/org/openjdk/asmtools/jasm/ConstantPool.java
+++ b/src/org/openjdk/asmtools/jasm/ConstantPool.java
@@ -483,6 +483,10 @@ public class ConstantPool implements Iterable<ConstantPool.ConstCell> {
             out.writeShort(arg);
         }
 
+        public int getRank() {
+            return this.rank;
+        }
+        
         public void setRank(int rank) {
             this.rank = rank;
         }


### PR DESCRIPTION
For example:
ldc     class Test; // setRank(0)
...
checkcast       class Test; // setRank(1) The ldc command will cause an error when the index is greater than 255
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewers
 * Leonid Kuskov ([lkuskov](@lkuskov) - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/asmtools pull/7/head:pull/7`
`$ git checkout pull/7`
