### PR TITLE
The first stackmap offset = 0 

### DIFF
--- a/src/org/openjdk/asmtools/jasm/CodeAttr.java
+++ b/src/org/openjdk/asmtools/jasm/CodeAttr.java
@@ -345,7 +345,8 @@ class CodeAttr extends AttrData {
                 break;
             default:
                 if (arg instanceof ConstantPool.ConstCell) {
-                    ((ConstantPool.ConstCell) arg).setRank(1);
+                    if (((ConstantPool.ConstCell) arg).getRank() != 0)
+                        ((ConstantPool.ConstCell) arg).setRank(1);
                 }
         }
         if (env.debugInfoFlag) {

--- a/src/org/openjdk/asmtools/jasm/ConstantPool.java
+++ b/src/org/openjdk/asmtools/jasm/ConstantPool.java
@@ -483,6 +483,10 @@ public class ConstantPool implements Iterable<ConstantPool.ConstCell> {
             out.writeShort(arg);
         }
 
+        public int getRank() {
+            return this.rank;
+        }
+
         public void setRank(int rank) {
             this.rank = rank;
         }

--- a/src/org/openjdk/asmtools/jdis/CodeData.java
+++ b/src/org/openjdk/asmtools/jdis/CodeData.java
@@ -173,7 +173,7 @@ public class CodeData extends Indenter {
         int stack_map_len = in.readUnsignedShort();
         TraceUtils.traceln(3,  "CodeAttr:  Stack_Map: attrlen=" + len + " num=" + stack_map_len);
         stack_map = new ArrayList<>(stack_map_len);
-        StackMapData.prevFramePC = 0;
+        StackMapData.prevFramePC = -1;
         for (int k = 0; k < stack_map_len; k++) {
             stack_map.add(new StackMapData(this, in));
         }
@@ -184,7 +184,7 @@ public class CodeData extends Indenter {
         int stack_map_len = in.readUnsignedShort();
         TraceUtils.traceln(3,  "CodeAttr:  Stack_Map_Table: attrlen=" + len + " num=" + stack_map_len);
         stack_map = new ArrayList<>(stack_map_len);
-        StackMapData.prevFramePC = 0;
+        StackMapData.prevFramePC = -1;
         for (int k = 0; k < stack_map_len; k++) {
             stack_map.add(new StackMapData(this, in, true));
         }

--- a/src/org/openjdk/asmtools/jdis/StackMapData.java
+++ b/src/org/openjdk/asmtools/jdis/StackMapData.java
@@ -35,7 +35,7 @@ import java.io.IOException;
  * represents one entry of StackMap attribute
  */
 class StackMapData {
-    static int prevFramePC = 0;
+    static int prevFramePC = -1;
     boolean isStackMapTable = false;
     StackMapFrameType stackFrameType = null;
     int start_pc;
@@ -108,7 +108,7 @@ class StackMapData {
 
         }
         stackFrameType = frame_type;
-        start_pc = prevFramePC == 0 ? offset : prevFramePC + offset + 1;
+        start_pc = prevFramePC == -1 ? offset : prevFramePC + offset + 1;
         prevFramePC = start_pc;
     }
 


### PR DESCRIPTION
I have the first stackmap offset = 0 of a class file
example:
StackMapTable: number_of_entries = 53
        frame_type = 0 /* same */
        frame_type = 252 /* append */
          offset_delta = 22
          locals = [ long ]
        frame_type = 255 /* full_frame */
          offset_delta = 21
          locals = []
          stack = [ class java/lang/Throwable ]
        frame_type = 255 /* full_frame */
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Download
`$ git fetch https://git.openjdk.java.net/asmtools pull/10/head:pull/10`
`$ git checkout pull/10`
