### PR TITLE
Created maven binding to make easy maven integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ hs_err_pid*
 
 # Misc: Intellij Idea,Mac OS
 /.idea/
+/maven/.idea/
 *.iml
 .DS_Store
 
+maven/target
+maven/src
+maven/pom.xml

--- a/maven/mvngen.sh
+++ b/maven/mvngen.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+#####################################################################################################
+# Symlinks are forbidden in openjdk project, thus we generate them on the fly togehter with pom.xml #
+#####################################################################################################
+
+set -eo pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+readonly PROJECT_DIR="$( readlink -f "$SCRIPT_DIR/.." )"
+
+PRODUCT_INFO="$PROJECT_DIR/build/productinfo.properties"
+
+function readProperty() {
+  cat "$PRODUCT_INFO" | grep "$1\s\+=" | sed "s/.*=\s\+//"
+}
+
+PRODUCT_NAME=$(readProperty "PRODUCT_NAME")
+PRODUCT_VERSION=$(readProperty "PRODUCT_VERSION")
+PRODUCT_MILESTONE=$(readProperty "PRODUCT_MILESTONE")
+PRODUCT_BUILDNUMBER=$(readProperty "PRODUCT_BUILDNUMBER")
+PRODUCT_NAME_LONG=$(readProperty "PRODUCT_NAME_LONG")
+
+echo "Generating $SCRIPT_DIR/pom.xml for $PRODUCT_NAME $PRODUCT_VERSION $PRODUCT_MILESTONE $PRODUCT_BUILDNUMBER ($PRODUCT_NAME_LONG)"
+cat "$SCRIPT_DIR/pom.xml.in" | \
+sed "s/\[PRODUCT_NAME\]/$PRODUCT_NAME/g" | \
+sed "s/\[PRODUCT_VERSION\]/$PRODUCT_VERSION/g" | \
+sed "s/\[PRODUCT_MILESTONE\]/$PRODUCT_MILESTONE/g" | \
+sed "s/\[PRODUCT_BUILDNUMBER\]/$PRODUCT_BUILDNUMBER/g" | \
+sed "s/\[PRODUCT_NAME_LONG\]/$PRODUCT_NAME_LONG/g" > "$SCRIPT_DIR/pom.xml"
+echo "Done"
+
+echo "Creating symlinks to symulate maven structure"
+FILES_LINKS="src/main/java/org=../../../../src/org/
+src/main/resources/org/openjdk/asmtools/i18n.properties=../../../../../../../src/org/openjdk/asmtools/i18n.properties
+src/main/resources/org/openjdk/asmtools/jasm/i18n.properties=../../../../../../../../src/org/openjdk/asmtools/jasm/i18n.properties
+src/main/resources/org/openjdk/asmtools/jcdec/i18n.properties=../../../../../../../../src/org/openjdk/asmtools/jcdec/i18n.properties
+src/main/resources/org/openjdk/asmtools/jcoder/i18n.properties=../../../../../../../../src/org/openjdk/asmtools/jcoder/i18n.properties
+src/main/resources/org/openjdk/asmtools/jdec/i18n.properties=../../../../../../../../src/org/openjdk/asmtools/jdec/i18n.properties
+src/main/resources/org/openjdk/asmtools/jdis/i18n.properties=../../../../../../../../src/org/openjdk/asmtools/jdis/i18n.properties
+src/main/resources/org/openjdk/asmtools/util/productinfo.properties=../../../../../../../../build/productinfo.properties"
+
+pushd $SCRIPT_DIR > /dev/null
+  for FILE_LINK in $FILES_LINKS ; do
+    FILE=$(echo "$FILE_LINK" | sed "s/=.*//")
+    LINK=$(echo "$FILE_LINK" | sed "s/.*=//")
+    DIR=$(dirname "$FILE")
+    NAME=$(basename "$FILE")
+    if [ ! -e "$SCRIPT_DIR/$FILE" ] ; then
+      mkdir -vp "$SCRIPT_DIR/$DIR"
+      pushd "$SCRIPT_DIR/$DIR" > /dev/null
+        echo "$SCRIPT_DIR/$DIR"
+        ln -sv "$LINK" "$NAME"
+      popd > /dev/null
+    fi
+  done
+popd > /dev/null
+echo "Done"
+
+

--- a/maven/pom.xml.in
+++ b/maven/pom.xml.in
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.openjdk</groupId>
+<!-- substituted from build/productinfo.properties -->
+    <artifactId>[PRODUCT_NAME]</artifactId>
+    <version>[PRODUCT_VERSION].b[PRODUCT_BUILDNUMBER]-[PRODUCT_MILESTONE]</version>
+<!--eg:      7.0.b10-ea-->
+    <packaging>jar</packaging>
+
+    <name>[PRODUCT_NAME]</name>
+    <description>Maven wrapper around [PRODUCT_NAME] - [PRODUCT_NAME_LONG] project</description>
+
+    <scm>
+        <url>https://github.com/openjdk/asmtools</url>
+        <connection>scm:git:https://git@github.com/openjdk/asmtools.git</connection>
+        <developerConnection>scm:git:https://git@github.com/openjdk/asmtools.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+  <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>org.openjdk.asmtools.Main</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Simplest maven wrapper without any duplicated code (with hardcoded version) to allow simple asmtools usage via maven depndencies. The namespace (org.openjdk) is same as for JMH

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Leonid Kuskov](https://openjdk.java.net/census#lkuskov) (@lkuskov - Committer)


### Download
`$ git fetch https://git.openjdk.java.net/asmtools pull/15/head:pull/15`
`$ git checkout pull/15`
