### PR TITLE
Added missing flushes

### DIFF
--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -108,6 +108,7 @@ public class Main extends Tool {
                 ClassData cc = new ClassData(dataInputStream, printFlags, out);
                 cc.DebugFlag = DebugFlag.getAsBoolean();
                 cc.decodeClass(inpname);
+                out.flush();
                 continue;
             } catch (Error ee) {
                 if (DebugFlag.getAsBoolean())

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -113,6 +113,7 @@ public class Main extends Tool {
                 ClassData cc = new ClassData(out, this);
                 cc.read(fname);
                 cc.print();
+                out.flush();
                 continue;
             } catch (Error ee) {
                 if (DebugFlag.getAsBoolean())


### PR DESCRIPTION
If the asmtools are used as library, and not just a cmdline tool, then it become visible, that stdouts are not properly closed.
This pr is adding flusehs jdis and jdec. Maybe the issue is more spread, but I was not using other parts library (yet)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Download
`$ git fetch https://git.openjdk.java.net/asmtools pull/16/head:pull/16`
`$ git checkout pull/16`
