### PR TITLE
7902892: jasm incorrectly processes reference_kind:reference_index pair in ldc Dynamic instructions

### DIFF
--- a/src/org/openjdk/asmtools/jasm/Scanner.java
+++ b/src/org/openjdk/asmtools/jasm/Scanner.java
@@ -183,7 +183,7 @@ prefix:
     protected final void check(Token t) throws SyntaxError, IOException {
         if (token != t) {
             if ((t != Token.IDENT) || !checkTokenIdent()) {
-                env.traceln("expect:" + t + " instead of " + token);
+                env.traceln("expect: " + t + " instead of " + token);
                 switch (t) {
                     case IDENT:
                         env.error(pos, "identifier.expected");

--- a/src/org/openjdk/asmtools/jasm/i18n.properties
+++ b/src/org/openjdk/asmtools/jasm/i18n.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -97,7 +97,9 @@ err.default.redecl=Default statement already declared in this table.
 err.long.switchtable=Switchtable too long: > {0}.
 err.io.exception=I/O error in {0}.
 warn.wrong.tag=Wrong tag: {0} expected.
-warn.wrong.tag2=Wrong tags: {0} or {1} expected.
+err.wrong.tag=Wrong tag: {0} expected.
+warn.wrong.tag2=Wrong tag: Either {0} or {1} expected.
+err.wrong.tag2=Wrong tag: Either {0} or {1} expected.
 # Code Gen:
 err.locvar.redecl=Local variable {0} redeclared.
 err.locvar.undecl=Local variable {0} not declared.


### PR DESCRIPTION
This is the fix for https://bugs.openjdk.java.net/browse/CODETOOLS-7902892
It unifies the processing of the LDC Dynamic instruction.
jasm will parse all dynamic instructions in the same way, i.e.
the following ldc produse the same bytecode: 
  ldc Dynamic REF_invokeInterface:InterfaceMethod LdcConDyTwice."method":".....
  ldc Dynamic REF_invokeInterface:LdcConDyTwice."method":".....
  ldc Dynamic REF_invokeInterface:"method":".....

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902892](https://bugs.openjdk.java.net/browse/CODETOOLS-7902892): jasm incorrectly processes reference_kind:reference_index pair in ldc Dynamic instructions


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/asmtools pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.java.net/asmtools pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/asmtools/pull/17.diff">https://git.openjdk.java.net/asmtools/pull/17.diff</a>

</details>
