### PR TITLE
7902913: jasm incorrectly processes the instruction pair: ldc MethodHandle  

### DIFF
--- a/src/org/openjdk/asmtools/jasm/JasmTokens.java
+++ b/src/org/openjdk/asmtools/jasm/JasmTokens.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools.jasm;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Optional;
 
@@ -415,6 +416,16 @@ public class JasmTokens {
                     filter(t->t.key_type == ktype).
                     filter(t->t.parsekey.equals(parsekey) || ( t.alias != null && t.alias.equals(parsekey))).
                     findFirst();
+        }
+
+        /**
+         * Checks that this enum element is in an enum list
+         *
+         * @param tokens the list of enum elements for checking
+         * @return true if a tokens list contains this enum element
+         */
+        public boolean in(Token... tokens) {
+            return (tokens == null) ? false : Arrays.asList(tokens).contains(this);
         }
 
         // By default, if a KeywordType is not specified, it has the value 'TOKEN'

--- a/src/org/openjdk/asmtools/jasm/Parser.java
+++ b/src/org/openjdk/asmtools/jasm/Parser.java
@@ -433,13 +433,18 @@ class Parser extends ParseBase {
      * ldc Dynamic REF_newInvokeSpecial:InterfaceMethod  LdcConDyTwice."<init>":
      * ldc Dynamic REF_invokeInterface:LdcConDyTwice."<init>":
      * ldc Dynamic REF_newInvokeSpecial:Method LdcConDyTwice."<init>":
+     * ldc MethodHandle REF_newInvokeSpecial:InterfaceMethod  LdcConDyTwice."<init>":
+     * ldc MethodHandle REF_invokeInterface:LdcConDyTwice."<init>":
+     * ldc MethodHandle REF_newInvokeSpecial:Method LdcConDyTwice."<init>":
+     * invokedynamic MethodHandle REF_invokeStatic:Method java/lang/invoke/StringConcatFactory.makeConcatWithConstants:
+     * invokedynamic MethodHandle REF_invokeStatic:java/lang/invoke/StringConcatFactory.makeConcatWithConstants
      * ....
      * @param position   the position in a source file
      * @param defaultTag expected reference_index tag (Method or InterfaceMethod)
      * @param defaultTag 2nd expected reference_index tag (Method or InterfaceMethod)
      */
     private void checkReferenceIndex(int position, ConstType defaultTag, ConstType default2Tag) {
-        if (scanner.token != COLON) {
+        if ( ! scanner.token.in(COLON, SEMICOLON) ) {
             if (default2Tag != null) {
                 env.error(position, "wrong.tag2", defaultTag.parseKey(), default2Tag.parseKey());
             } else {


### PR DESCRIPTION
This fix is for https://bugs.openjdk.java.net/browse/CODETOOLS-7902913
that is the regression of the fix for https://bugs.openjdk.java.net/browse/CODETOOLS-7902892
The fix adds the token SEMICOLON to the list of alllowed which was missed in the metod checkReferenceIndex that checks a token that follows  reference_kind:[reference_index | [class|interface] | method]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902913](https://bugs.openjdk.java.net/browse/CODETOOLS-7902913): jasm incorrectly processes the instruction pair: ldc MethodHandle


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/asmtools pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/asmtools pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/asmtools/pull/18.diff">https://git.openjdk.java.net/asmtools/pull/18.diff</a>

</details>
