### PR TITLE
Added gpg plugin and steps for release

### DIFF
--- a/maven/pom.xml.in
+++ b/maven/pom.xml.in
@@ -24,7 +24,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-
     <build>
         <!-- Although the symlinks are correct, and working, source plugin is unable to resolve them, thus pointing it to the original sources-->
         <sourceDirectory>../src</sourceDirectory>
@@ -81,7 +80,38 @@
                         </goals>
                     </execution>
                 </executions>
-           </plugin>
+            </plugin>
+            <plugin>
+                <!--to release, obtain credentials to org.openjdk via https://central.sonatype.org/publish/publish-guide/#create-a-ticket-with-sonatype and working and valid gpg keys
+                    once (both) active, and you have working verified artifacts, you can execute:
+                         mvn clean verify gpg:sign install:install deploy:deploy -DaltDeploymentRepository=ossrh::default::https://oss.sonatype.org/service/local/staging/deploy/maven2/ 
+                    to upload to maven staging. With deploy to central (preferably via gui) follow https://central.sonatype.org/publish/publish-guide/ guide
+                    note, that org.openjdk is indeed on https://oss.sonatype.org/ not on https://s01.oss.sonatype.org
+                    Dont forget to have:
+                         <servers>
+                           <server>
+                             <id>ossrh</id>
+                             <username>...</username>
+                             <password>...</password>
+                           </server>
+                         </servers>
+                   in your ~/.m2/settings.xml
+                   See https://issues.sonatype.org/browse/OSSRH-69690 for exmaple
+                   The manual release process is in place, as we do not wont release plugin and simialr to use tags, or even make tags in https://git@github.com/openjdk/asmtools.git (at leaset for now)
+                -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                           <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/maven/pom.xml.in
+++ b/maven/pom.xml.in
@@ -13,6 +13,44 @@
 
     <name>[PRODUCT_NAME]</name>
     <description>Maven wrapper around [PRODUCT_NAME] - [PRODUCT_NAME_LONG] project</description>
+    <url>https://github.com/openjdk/asmtools</url>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License v2.0</name>
+            <url>https://github.com/openjdk/asmtools/blob/master/LICENSE</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <!-- this list not intended to be complete, see contributors at project pages-->
+        <developer>
+            <id>lkuskov</id>
+            <name>Leonid Kuskov</name>
+            <email>leonid.kuskov@oracle.com</email>
+            <organization>Oracle</organization>
+            <organizationUrl>http://www.oracle.com</organizationUrl>
+        </developer>
+        <developer>
+            <id>maccimo</id>
+            <name>Maxim Degtyarev</name>
+            <email>maccimo@github.com</email>
+        </developer>
+        <developer>
+            <id>edvbld</id>
+            <name>Erik Duveblad</name>
+            <email>erikd.duveblad@oracle.com</email>
+            <organization>Oracle</organization>
+            <organizationUrl>http://www.oracle.com</organizationUrl>
+        </developer>
+        <developer>
+            <id>judovana</id>
+            <name>Jiri Vanek</name>
+            <email>jvanek@redhat.com</email>
+            <organization>Redhat</organization>
+            <organizationUrl>http://www.redhat.com</organizationUrl>
+        </developer>
+    </developers>
 
     <scm>
         <url>https://github.com/openjdk/asmtools</url>
@@ -20,9 +58,10 @@
         <developerConnection>scm:git:https://git@github.com/openjdk/asmtools.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-  <properties>
+
+    <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+    </properties>
 
     <build>
         <!-- Although the symlinks are correct, and working, source plugin is unable to resolve them, thus pointing it to the original sources-->


### PR DESCRIPTION
Usually the maven release plugin or gpg release plugin are working with direct access to repo - push change of versions, tag, do release, and again bump versions for next development cycle. As for asmtools, the maven is just secondary, unsupported release medium so I had opted for upload of locally finished binaries. Thus the manual ```mvn clean verify gpg:sign install:install deploy:deploy -DaltDeploymentRepository=ossrh::default::https://oss.sonatype.org/service/local/staging/deploy/maven2/ ```  command in pom comment. 
This may not be best, but for now it is the only way I found to upload locally created binaries. But I must admit, I'm not 100% sure in maven reelase or gpg plugins. During the next releases, maybe I will find something better.

As the PR is now, the asmtools artifacts are uploaded in staging maven central: https://oss.sonatype.org/content/repositories/orgopenjdkasmtools-1002/org/openjdk/asmtools/asmtools-core/

I had tested it and it works as expected (https://github.com/pmikova/java-runtime-decompiler/commit/d8b5a03759b9e8dfe584b0052778ff590ba6e82b).

One offtopic question  - the {slash}integrate and/or {slash}sponsor is autoamtically squashing commits?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/asmtools pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/asmtools pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/asmtools/pull/20.diff">https://git.openjdk.java.net/asmtools/pull/20.diff</a>

</details>
