### PR TITLE
7903208: [Jasm] Add support for generics (the `Signature` attribute)

### DIFF
--- a/src/org/openjdk/asmtools/jasm/ClassData.java
+++ b/src/org/openjdk/asmtools/jasm/ClassData.java
@@ -443,6 +443,8 @@ class ClassData extends MemberData {
                 attrs.add(syntheticAttr);
             if (deprecatedAttr != null)
                 attrs.add(deprecatedAttr);
+            if (signatureAttr != null)
+                attrs.add(signatureAttr);
             if (annotAttrVis != null)
                 attrs.add(annotAttrVis);
             if (annotAttrInv != null)

--- a/src/org/openjdk/asmtools/jasm/JasmTokens.java
+++ b/src/org/openjdk/asmtools/jasm/JasmTokens.java
@@ -377,6 +377,7 @@ public class JasmTokens {
         BOOTSTRAPMETHOD     (172, "BOOTSTRAPMETHOD", "BootstrapMethod", EnumSet.of(TokenType.DECLARATION, TokenType.JASM_IDENT, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
         NESTHOST            (173, "NESTHOST",       "NestHost",         EnumSet.of(TokenType.DECLARATION, TokenType.JASM_IDENT, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
         NESTMEMBERS         (174, "NESTMEMBERS",    "NestMembers",      EnumSet.of(TokenType.DECLARATION, TokenType.JASM_IDENT, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
+        SIGNATURE           (188, "SIGNATURE",       "Signature",       EnumSet.of(TokenType.DECLARATION, TokenType.JASM_IDENT, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
         //
         RECORD              (175, "RECORD",    "Record",                EnumSet.of(TokenType.DECLARATION, TokenType.JASM_IDENT, TokenType.MODULE_NAME ), KeywordType.KEYWORD),
         COMPONENT           (176, "COMPONENT", "Component",             EnumSet.of(TokenType.DECLARATION, TokenType.JASM_IDENT, TokenType.MODULE_NAME ), KeywordType.KEYWORD),

--- a/src/org/openjdk/asmtools/jasm/MethodData.java
+++ b/src/org/openjdk/asmtools/jasm/MethodData.java
@@ -207,7 +207,7 @@ class MethodData extends MemberData {
 
     @Override
     protected DataVector getAttrVector() {
-        DataVector dv = getDataVector( exceptions, syntheticAttr, deprecatedAttr, paramNames, code, defaultAnnot);
+        DataVector dv = getDataVector(exceptions, syntheticAttr, deprecatedAttr, signatureAttr, paramNames, code, defaultAnnot);
         if (pannotAttrVis != null) {
             dv.add(pannotAttrVis);
         }

--- a/src/org/openjdk/asmtools/jdis/ClassData.java
+++ b/src/org/openjdk/asmtools/jdis/ClassData.java
@@ -24,6 +24,7 @@ package org.openjdk.asmtools.jdis;
 
 import org.openjdk.asmtools.asmutils.HexUtils;
 import org.openjdk.asmtools.common.Tool;
+import org.openjdk.asmtools.jasm.JasmTokens;
 import org.openjdk.asmtools.jasm.Modifiers;
 
 import java.io.*;
@@ -37,6 +38,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 import static org.openjdk.asmtools.jasm.RuntimeConstants.*;
 import static org.openjdk.asmtools.jasm.Tables.*;
+import static org.openjdk.asmtools.jdis.TraceUtils.traceln;
 
 /**
  * Central class data for of the Java Disassembler
@@ -182,6 +184,13 @@ public class ClassData extends MemberData {
         // Read the Attributes
         boolean handled = true;
         switch (attrtag) {
+            case ATT_Signature:
+                if( signature != null ) {
+                    traceln("Class attribute:  more than one attribute Signature are in ClassFile.attribute_info_attributes[attribute_count]");
+                    traceln("Last one will be used.");
+                }
+                signature = new SignatureData(cls).read(in, attrlen);
+                break;
             case ATT_SourceFile:
                 // Read SourceFile Attr
                 if (attrlen != 2) {
@@ -436,6 +445,12 @@ printSugar:
         }
         // Don't print fields, methods, inner classes and bootstrap methods if it is module-info entity
         if ( !isModuleUnit() ) {
+
+            if (signature != null) {
+                signature.print(getIndentString() + JasmTokens.Token.SIGNATURE.parseKey() + " ", pr_cpx ? ";\t // " : ";");
+                out.println();
+                out.println();
+            }
 
             // Print the fields
             printMemberDataList(fields);

--- a/src/org/openjdk/asmtools/jdis/FieldData.java
+++ b/src/org/openjdk/asmtools/jdis/FieldData.java
@@ -57,7 +57,7 @@ public class FieldData extends MemberData {
         switch (attrtag) {
             case ATT_Signature:
                 if( signature != null ) {
-                    traceln("Record attribute:  more than one attribute Signature are in component.attribute_info_attributes[attribute_count]");
+                    traceln("Field attribute:  more than one attribute Signature are in field_info.attribute_info_attributes[attribute_count]");
                     traceln("Last one will be used.");
                 }
                 signature = new SignatureData(cls).read(in, attrlen);


### PR DESCRIPTION
Turns out, this was already supported for fields and record components (since commit <https://github.com/openjdk/asmtools/commit/5d26c9a084ed7e4be6e45e3892c06e8ce2dbd084>), but not for classes or methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [CODETOOLS-7903208](https://bugs.openjdk.org/browse/CODETOOLS-7903208): [Jasm] Add support for generics (the `Signature` attribute)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/asmtools pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/21.diff">https://git.openjdk.org/asmtools/pull/21.diff</a>

</details>
