### PR TITLE
Added tests to represent bad stream handling in jdec and correct one in jdis

### DIFF
--- a/maven/mvngen.sh
+++ b/maven/mvngen.sh
@@ -51,6 +51,7 @@ echo "Done"
 
 echo "Creating symlinks to symulate maven structure"
 FILES_LINKS="src/main/java/org=../../../../src/org/
+src/test/java/org=../../../../test/org/
 src/main/resources/org/openjdk/asmtools/i18n.properties=../../../../../../../src/org/openjdk/asmtools/i18n.properties
 src/main/resources/org/openjdk/asmtools/jasm/i18n.properties=../../../../../../../../src/org/openjdk/asmtools/jasm/i18n.properties
 src/main/resources/org/openjdk/asmtools/jcdec/i18n.properties=../../../../../../../../src/org/openjdk/asmtools/jcdec/i18n.properties

--- a/maven/pom.xml.in
+++ b/maven/pom.xml.in
@@ -24,7 +24,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-
     <build>
         <plugins>
             <plugin>
@@ -35,6 +34,11 @@
                     <source>[SOURCE]</source>
                     <target>[TARGET]</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M7</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -51,5 +55,15 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencies>
+      <!-- For tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.0-M1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/test/org/openjdk/asmtools/ThreeStringWriters.java
+++ b/test/org/openjdk/asmtools/ThreeStringWriters.java
@@ -1,0 +1,43 @@
+package org.openjdk.asmtools;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+
+public class ThreeStringWriters {
+    private final ByteArrayOutputStream toolBos = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errorBos = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream loggerBos = new ByteArrayOutputStream();
+    private final PrintWriter toolOutput = new PrintWriter(toolBos);
+    private final PrintWriter errorOutput = new PrintWriter(errorBos);
+    private final PrintWriter loggerOutput = new PrintWriter(loggerBos);
+
+    public void flush(){
+        toolOutput.flush();
+        errorOutput.flush();
+        loggerOutput.flush();
+    }
+
+    public PrintWriter getToolOutput() {
+        return toolOutput;
+    }
+
+    public PrintWriter getErrorOutput() {
+        return errorOutput;
+    }
+
+    public PrintWriter getLoggerOutput() {
+        return loggerOutput;
+    }
+
+    public String getLoggerBos() {
+        return loggerBos.toString();
+    }
+
+    public String getErrorBos() {
+        return errorBos.toString();
+    }
+
+    public String getToolBos() {
+        return toolBos.toString();
+    }
+}

--- a/test/org/openjdk/asmtools/jdec/MainTest.java
+++ b/test/org/openjdk/asmtools/jdec/MainTest.java
@@ -1,0 +1,40 @@
+package org.openjdk.asmtools.jdec;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openjdk.asmtools.ThreeStringWriters;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+class MainTest {
+
+    @Test
+    public void main3StreamsNoSuchFileError() {
+        ThreeStringWriters outs = new ThreeStringWriters();
+        String nonExisitngFile = "someNonExiostingFile";
+        //for 0 file args, there is hardcoded System.exit
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{nonExisitngFile});
+        int i = decoder.decode();
+        outs.flush();
+        Assertions.assertEquals(1, i);
+        Assertions.assertTrue(outs.getToolBos().isEmpty());
+        Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+        Assertions.assertTrue(outs.getErrorBos().contains("No such file"));
+        Assertions.assertTrue(outs.getErrorBos().contains(nonExisitngFile));
+    }
+
+    @Test
+    public void main3StreamsFileInCorrectStream() throws IOException {
+        ThreeStringWriters outs = new ThreeStringWriters();
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{"./target/classes/org/openjdk/asmtools/jdec/Main.class"});
+        int i = decoder.decode();
+        outs.flush();
+        Assertions.assertEquals(0, i);
+        Assertions.assertFalse(outs.getToolBos().isEmpty());
+        Assertions.assertTrue(outs.getErrorBos().isEmpty());
+        Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+    }
+
+}

--- a/test/org/openjdk/asmtools/jdis/MainTest.java
+++ b/test/org/openjdk/asmtools/jdis/MainTest.java
@@ -1,0 +1,38 @@
+package org.openjdk.asmtools.jdis;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openjdk.asmtools.ThreeStringWriters;
+
+import java.io.IOException;
+
+class MainTest {
+
+    @Test
+    public void main3StreamsNoSuchFileError() {
+        ThreeStringWriters outs = new ThreeStringWriters();
+        String nonExisitngFile = "someNonExiostingFile";
+        //for 0 file args, there is hardcoded System.exit
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{nonExisitngFile});
+        int i = decoder.disasm();
+        outs.flush();
+        Assertions.assertEquals(1, i);
+        Assertions.assertTrue(outs.getToolBos().isEmpty());
+        Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+        Assertions.assertTrue(outs.getErrorBos().contains("No such file"));
+        Assertions.assertTrue(outs.getErrorBos().contains(nonExisitngFile));
+    }
+
+    @Test
+    public void main3StreamsFileInCorrectStream() throws IOException {
+        ThreeStringWriters outs = new ThreeStringWriters();
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{"./target/classes/org/openjdk/asmtools/jdis/Main.class"});
+        int i = decoder.disasm();
+        outs.flush();
+        Assertions.assertEquals(0, i);
+        Assertions.assertFalse(outs.getToolBos().isEmpty());
+        Assertions.assertTrue(outs.getErrorBos().isEmpty());
+        Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+    }
+
+}


### PR DESCRIPTION
The tests are now maven only. I do not knwo how to add them properly to the ant task, without introducing ivy to download junit jupiter runner, or to add burden of some wgetted dependencies.

WDYT?

The tests represents the issue with messe dusp tream in jdecoder, and correct behaviour in jdis.
I hoped I will provide fix asap once the tests ar ehere, but the inheritance there was quite a surprised, so now I'm double checking what would be actually broken by the "swap" of the jdec streams back to "normal".
Do you have some quick guidance how to force somethng to loggerOutput please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.org/asmtools pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/23.diff">https://git.openjdk.org/asmtools/pull/23.diff</a>

</details>
