### PR TITLE
Made jdec to write output to proer toolOutput instead of bad logOutput

### DIFF
--- a/src/org/openjdk/asmtools/jdec/JdecEnvironment.java
+++ b/src/org/openjdk/asmtools/jdec/JdecEnvironment.java
@@ -28,6 +28,8 @@ import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.PrintWriter;
 
+import static java.lang.String.format;
+
 public class JdecEnvironment extends Environment<DecompilerLogger> {
 
     protected boolean printDetailsFlag;
@@ -56,17 +58,22 @@ public class JdecEnvironment extends Environment<DecompilerLogger> {
 
     @Override
     public void println(String format, Object... args) {
-        super.println(format, args);
+        getToolOutput().println(( args == null || args.length == 0) ? format : format(format, args));
     }
 
     @Override
     public void println() {
-        super.println();
+        getToolOutput().println();
     }
 
     @Override
     public void print(String format, Object... args) {
-        super.print(format, args);
+        getToolOutput().print(( args == null || args.length == 0) ? format : format(format, args));
+    }
+
+    @Override
+    public void print(char ch) {
+        getToolOutput().print(ch);
     }
 
 


### PR DESCRIPTION
Hello!

This is fixing the bad streams of jdec in at8, and is making the tests in https://github.com/openjdk/asmtools/pull/23 to pass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.org/asmtools pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/24.diff">https://git.openjdk.org/asmtools/pull/24.diff</a>

</details>
