### PR TITLE
   Replaced hardcoded String[] args, by varargs String... where reasonable

### DIFF
--- a/src/org/openjdk/asmtools/Main.java
+++ b/src/org/openjdk/asmtools/Main.java
@@ -38,7 +38,7 @@ public class Main {
      *
      * @param args - command line arguments
      */
-    public static void main(String args[]) {
+    public static void main(String... args) {
         if (args.length == 0) {
             usage(i18n.getString("main.error.no_arguments"), 1);
         }
@@ -90,35 +90,35 @@ public class Main {
     /**
      * Invokes jasm main class with passed arguments
      */
-    public static void jasm(String[] args) {
+    public static void jasm(String... args) {
         org.openjdk.asmtools.jasm.Main.main(args);
     }
 
     /**
      * Invokes jcdec main class with passed arguments
      */
-    public static void jcdec(String[] args) {
+    public static void jcdec(String... args) {
         org.openjdk.asmtools.jcdec.Main.main(args);
     }
 
     /**
      * Invokes jcoder main class with passed arguments
      */
-    public static void jcoder(String[] args) {
+    public static void jcoder(String... args) {
         org.openjdk.asmtools.jcoder.Main.main(args);
     }
 
     /**
      * Invokes jdec main class with passed arguments
      */
-    public static void jdec(String[] args) {
+    public static void jdec(String... args) {
         org.openjdk.asmtools.jdec.Main.main(args);
     }
 
     /**
      * Invokes jdis main class with passed arguments
      */
-    public static void jdis(String[] args) {
+    public static void jdis(String... args) {
         org.openjdk.asmtools.jdis.Main.main(args);
     }
 }

--- a/src/org/openjdk/asmtools/common/Tool.java
+++ b/src/org/openjdk/asmtools/common/Tool.java
@@ -67,9 +67,9 @@ public abstract class Tool<T extends Environment<? extends ToolLogger>> {
     protected abstract void usage();
 
     // Parse arguments. Tool will be left using System.Exit if error found.
-    protected abstract void parseArgs(String[] argv);
+    protected abstract void parseArgs(String... argv);
 
-    protected File setDestDir(int index, String[] argv) {
+    protected File setDestDir(int index, String... argv) {
         File destDir;
         if ((index) >= argv.length) {
             environment.error("err.d_requires_argument");

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -63,18 +63,18 @@ public class Main extends JasmTool {
     private boolean debugAnnot = false;
     private boolean debugInstr = false;
 
-    public Main(String[] argv) {
+    public Main(String... argv) {
         super();
         parseArgs(argv);
     }
 
-    public Main(PrintWriter errorLogger, PrintWriter outputLogger, String[] argv) {
+    public Main(PrintWriter errorLogger, PrintWriter outputLogger, String... argv) {
         super(errorLogger, outputLogger);
         parseArgs(argv);
     }
 
     // jasm entry point
-    public static void main(String[] argv) {
+    public static void main(String... argv) {
         Main compiler = new Main(new PrintWriter(System.err, true),
                 new PrintWriter(System.out, true), argv);
         System.exit(compiler.compile());
@@ -130,7 +130,7 @@ public class Main extends JasmTool {
     }
 
     @Override
-    protected void parseArgs(String[] argv) {
+    protected void parseArgs(String... argv) {
         try {
             // Parse arguments
             for (int i = 0; i < argv.length; i++) {

--- a/src/org/openjdk/asmtools/jcdec/Main.java
+++ b/src/org/openjdk/asmtools/jcdec/Main.java
@@ -856,7 +856,7 @@ public class Main {
     /**
      * Run the decoder
      */
-    public synchronized boolean decode(String argv[]) {
+    public synchronized boolean decode(String... argv) {
 //      int flags = F_WARNINGS;
         long tm = System.currentTimeMillis();
         ArrayList<String> vargs = new ArrayList<>();
@@ -950,7 +950,7 @@ decode:
     /**
      * Main program
      */
-    public static void main(String argv[]) {
+    public static void main(String... argv) {
         Main decoder = new Main(new PrintWriter(new uEscWriter(System.out)), "jcdec");
         System.exit(decoder.decode(argv) ? 0 : 1);
     }

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -49,18 +49,18 @@ public class Main extends JcoderTool {
     private boolean noWriteFlag = false;        // Do not write generated class files
     private boolean ignoreFlag = false;         // Ignore non-fatal error(s) that suppress writing class files
 
-    public Main(String[] argv) {
+    public Main(String... argv) {
         super();
         parseArgs(argv);
     }
 
-    public Main(PrintWriter errorLogger, PrintWriter outputLogger, String[] argv) {
+    public Main(PrintWriter errorLogger, PrintWriter outputLogger, String... argv) {
         super(errorLogger, outputLogger);
         parseArgs(argv);
     }
 
     // jcoder entry point
-    public static void main(String[] argv) {
+    public static void main(String... argv) {
         Main compiler = new Main(argv);
         System.exit(compiler.compile());
     }
@@ -105,7 +105,7 @@ public class Main extends JcoderTool {
     }
 
     @Override
-    protected void parseArgs(String[] argv) {
+    protected void parseArgs(String... argv) {
         try {
             // Parse arguments
             for (int i = 0; i < argv.length; i++) {

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -41,23 +41,23 @@ public class Main extends JdecTool {
 
     private ArrayList<String> fileList = new ArrayList<>();
 
-    public Main(PrintStream toolOutput, String[] argv) {
+    public Main(PrintStream toolOutput, String... argv) {
         super(toolOutput);
         parseArgs(argv);
     }
 
-    public Main(PrintWriter toolOutput, String[] argv) {
+    public Main(PrintWriter toolOutput, String... argv) {
         super(toolOutput);
         parseArgs(argv);
     }
 
-    public Main(PrintWriter toolOutput, PrintWriter errorOutput, PrintWriter loggerOutput, String[] argv) {
+    public Main(PrintWriter toolOutput, PrintWriter errorOutput, PrintWriter loggerOutput, String... argv) {
         super(toolOutput, errorOutput, loggerOutput);
         parseArgs(argv);
     }
 
     // jdec entry point
-    public static void main(String[] argv) {
+    public static void main(String... argv) {
         Main decoder = new Main(new PrintWriter(new uEscWriter(System.out)), argv);
         System.exit(decoder.decode());
     }
@@ -79,7 +79,7 @@ public class Main extends JdecTool {
 //    /**
 //     * Main program
 //     */
-//    public static void main(String argv[]) {
+//    public static void main(String... argv) {
 //        Main decoder = new Main(new PrintWriter(new uEscWriter(System.out)), new PrintWriter(System.err), "jdec");
 //        System.exit(decoder.decode(argv) ? 0 : 1);
 //    }
@@ -93,7 +93,7 @@ public class Main extends JdecTool {
     }
 
     @Override
-    protected void parseArgs(String[] argv) {
+    protected void parseArgs(String... argv) {
         // Parse arguments
         for (String arg : argv) {
             switch (arg) {

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -46,23 +46,23 @@ public class Main extends JdisTool {
 
     private ArrayList<String> fileList = new ArrayList<>();
 
-    public Main(PrintStream toolOutput, String[] argv) {
+    public Main(PrintStream toolOutput, String... argv) {
         super(toolOutput);
         parseArgs(argv);
     }
 
-    public Main(PrintWriter toolOutput, String[] argv) {
+    public Main(PrintWriter toolOutput, String... argv) {
         super(toolOutput);
         parseArgs(argv);
     }
 
-    public Main(PrintWriter toolOutput, PrintWriter errorOutput, PrintWriter loggerOutput, String[] argv) {
+    public Main(PrintWriter toolOutput, PrintWriter errorOutput, PrintWriter loggerOutput, String... argv) {
         super(toolOutput, errorOutput, loggerOutput);
         parseArgs(argv);
     }
 
     // jdis entry point
-    public static void main(String[] argv) {
+    public static void main(String... argv) {
         Main disassembler = new Main(new PrintWriter(new uEscWriter(System.out)), argv);
         System.exit(disassembler.disasm());
     }
@@ -111,7 +111,7 @@ public class Main extends JdisTool {
     }
 
     @Override
-    protected void parseArgs(String[] argv) {
+    protected void parseArgs(String... argv) {
         // Parse arguments
         for (String arg : argv) {
             switch (arg) {

--- a/test/org/openjdk/asmtools/jdec/MainTest.java
+++ b/test/org/openjdk/asmtools/jdec/MainTest.java
@@ -15,7 +15,7 @@ class MainTest {
         ThreeStringWriters outs = new ThreeStringWriters();
         String nonExisitngFile = "someNonExiostingFile";
         //for 0 file args, there is hardcoded System.exit
-        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{nonExisitngFile});
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), nonExisitngFile);
         int i = decoder.decode();
         outs.flush();
         Assertions.assertEquals(1, i);
@@ -28,7 +28,7 @@ class MainTest {
     @Test
     public void main3StreamsFileInCorrectStream() throws IOException {
         ThreeStringWriters outs = new ThreeStringWriters();
-        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{"./target/classes/org/openjdk/asmtools/jdec/Main.class"});
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), "./target/classes/org/openjdk/asmtools/jdec/Main.class");
         int i = decoder.decode();
         outs.flush();
         Assertions.assertEquals(0, i);

--- a/test/org/openjdk/asmtools/jdis/MainTest.java
+++ b/test/org/openjdk/asmtools/jdis/MainTest.java
@@ -13,7 +13,7 @@ class MainTest {
         ThreeStringWriters outs = new ThreeStringWriters();
         String nonExisitngFile = "someNonExiostingFile";
         //for 0 file args, there is hardcoded System.exit
-        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{nonExisitngFile});
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), nonExisitngFile);
         int i = decoder.disasm();
         outs.flush();
         Assertions.assertEquals(1, i);
@@ -26,7 +26,7 @@ class MainTest {
     @Test
     public void main3StreamsFileInCorrectStream() throws IOException {
         ThreeStringWriters outs = new ThreeStringWriters();
-        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), new String[]{"./target/classes/org/openjdk/asmtools/jdis/Main.class"});
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), "./target/classes/org/openjdk/asmtools/jdis/Main.class");
         int i = decoder.disasm();
         outs.flush();
         Assertions.assertEquals(0, i);


### PR DESCRIPTION
Replaced hardcoded String[] args, by varargs String... where reasonable
    
    Once the "tool" mandatory array memebr was removed from each tool's main
    method, and considering calls from libraries, and form tests where the
    argument is very often just one file, or more readable "a1", a2"...
    without new String[]{} declaration, changed those String[] enforcing
    headers to more benevolent String...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/asmtools pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/25.diff">https://git.openjdk.org/asmtools/pull/25.diff</a>

</details>
