### PR TITLE
Intentionally removed ACC_SUPER class modifier was causing hotswap to fail

### DIFF
--- a/src/org/openjdk/asmtools/common/structure/EModifier.java
+++ b/src/org/openjdk/asmtools/common/structure/EModifier.java
@@ -45,7 +45,10 @@ public enum EModifier {
 
     ACC_FINAL(0x0010, "final", CLASS, INNER_CLASS, FIELD, METHOD, METHOD_PARAMETERS),
 
-    ACC_SUPER(0x0020, "super", CLASS),                                    // <<ignored>>
+    ACC_SUPER(0x0020, "super", CLASS),   // although this seems to be easily ignored, but not including it to the class, where it originally was,
+                                                      // will cause running hotswap to fail, with
+                                                      //java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the class modifiers
+
     ACC_TRANSITIVE(0x0020, "transitive", REQUIRES),
     ACC_SYNCHRONIZED(0x0020, "synchronized", METHOD),
     ACC_OPEN(0x0020, "open", MODULE),
@@ -368,9 +371,9 @@ public enum EModifier {
                     // In Java SE 8, the ACC_SUPER semantics became mandatory,
                     // regardless of the setting of ACC_SUPER or the class file version number,
                     // and the flags no longer had any effect.
-                    if (isName) {
-                        list.add(ACC_SUPER.getFlagName());
-                    }
+                    // still we have to keep it in here (if it was here), as if the new class is used for hotswap, it s absence would casue
+                    // java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the class modifiers
+                    flags = addTo(list, flags, isName, ACC_SUPER);
                 }
                 case REQUIRES -> flags = addTo(list, flags, isName, ACC_TRANSITIVE);
                 case METHOD -> flags = addTo(list, flags, isName, ACC_SYNCHRONIZED);

--- a/src/org/openjdk/asmtools/jdis/ClassData.java
+++ b/src/org/openjdk/asmtools/jdis/ClassData.java
@@ -401,8 +401,8 @@ public class ClassData extends MemberData<ClassData> {
             printAnnotations(visibleTypeAnnotations, invisibleTypeAnnotations);
             // In Java SE 8, the ACC_SUPER semantics became mandatory, regardless of the setting of ACC_SUPER or
             // the class file version number, and the flag no longer had any effect.
-            // Skip printing "super modifier"
-            access &= ~ACC_SUPER.getFlag();
+            // however, to not print it where it was, would cause hotswap of such class to
+            // throw java.lang.UnsupportedOperationException: class redefinition failed: attempted to change the class modifiers
 
             String name = pool.inRange(this_cpx) ? pool.getShortClassName(this_cpx, this.packageName) :  "?? invalid index";
             Pair<String, String> signInfo = ( signature != null) ?

--- a/test/org/openjdk/asmtools/jdis/MainTest.java
+++ b/test/org/openjdk/asmtools/jdis/MainTest.java
@@ -35,4 +35,25 @@ class MainTest {
         Assertions.assertTrue(outs.getLoggerBos().isEmpty());
     }
 
+
+    @Test
+    public void superIsNotOmited() throws IOException {
+        ThreeStringWriters outs = new ThreeStringWriters();
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), "./target/classes/org/openjdk/asmtools/jdis/Main.class");
+        int i = decoder.disasm();
+        outs.flush();
+        Assertions.assertEquals(0, i);
+        Assertions.assertFalse(outs.getToolBos().isEmpty());
+        Assertions.assertTrue(outs.getErrorBos().isEmpty());
+        Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+        String clazz = outs.getToolBos();
+        for(String line: clazz.split("\n")) {
+            if (line.contains("class Main extends JdisTool")){
+                Assertions.assertTrue(line.contains("super"), "class declaration had super omitted - " + line);
+                return;
+            }
+        }
+        Assertions.assertTrue(false, "class Main was not found in disassembled output");
+    }
+
 }


### PR DESCRIPTION
When jasm's  disasm, modify, asm cycle output binary was used for class
hotswap, remote JDK was not accepting it with java.lang.UnsupportedOperationException:
class redefinition failed: attempted to change the class modifiers
beacuse of ommited supoer keyword (although it have already no real
reason)

This patch is returning the keyword without conditions, when it was
included in original bytecode

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/asmtools pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/26.diff">https://git.openjdk.org/asmtools/pull/26.diff</a>

</details>
