### PR TITLE
added tests if asmtools assmble itself into valid bytecode

### DIFF
--- a/test/org/openjdk/asmtools/BruteForceHelper.java
+++ b/test/org/openjdk/asmtools/BruteForceHelper.java
@@ -1,0 +1,189 @@
+package org.openjdk.asmtools;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class BruteForceHelper {
+
+    public static final String FRESHLY_BUILT_ASMTOOLS = "target/classes";
+
+    private final ClassProvider classProvider;
+
+    private final Map<File, ThreeStringWriters> failedJdis = new HashMap<>();
+    private final Map<File, ThreeStringWriters> passedJdis = new HashMap<>();
+    private final Map<File, ThreeStringWriters> failedJasm = new HashMap<>();
+    private final Map<File, ThreeStringWriters> passedJasm = new HashMap<>();
+    private final Map<File, ThreeStringWriters> failedLoad = new HashMap<>();
+    private final Map<File, ThreeStringWriters> passedLoad = new HashMap<>();
+    private final File compileDir;
+
+    public BruteForceHelper() throws IOException {
+        this(FRESHLY_BUILT_ASMTOOLS);
+    }
+
+    public BruteForceHelper(String dir) throws IOException {
+        this(new SearchingClassProvider(new File(dir)));
+    }
+
+    public BruteForceHelper(ClassProvider cp) throws IOException {
+        compileDir = Files.createTempDirectory("JdisJasmWorks").toFile();
+        compileDir.deleteOnExit();
+        classProvider = cp;
+    }
+
+    public void work(AsmToolsExecutable diasm, AsmToolsExecutable asm) throws IOException {
+        List<File> classes = classProvider.getClasses();
+        tryAll(classes, failedJdis, passedJdis, diasm);
+        diasm.ensure(classes, failedJdis);
+
+        tryAll(classes, failedJasm, passedJasm, asm);
+        asm.ensure(classes, failedJasm);
+
+        AsmToolsExecutable loadClass = new AsmToolsExecutable() {
+            @Override
+            public int run(ThreeStringWriters outs, File clazz) throws IOException {
+                try {
+                    URL url = compileDir.toURI().toURL();
+                    URL[] urls = new URL[]{url};
+                    URLClassLoader cl = new URLClassLoader(urls);
+                    String[] metadata = passedJasm.get(clazz).getToolBos().split("\n"); //npe on this get means, that passedJasm dont contains all so  the missing peace is in failedJasm, which's assert is commented out?
+                    String origFile = metadata[0].replaceFirst(".*: ", "");
+                    String baseDir = metadata[2].replaceFirst(".*: ", "");
+                    String fqn = origFile.replaceFirst(baseDir + "/", "").replaceFirst("\\.class$", "").replaceAll("/", ".");
+                    Class cls = cl.loadClass(fqn);
+                    return 0;
+                } catch (Exception e) {
+                    e.printStackTrace(outs.getToolOutput());
+                    return 1;
+                }
+            }
+
+            @Override
+            public void ensure(List<File> all, Map<File, ThreeStringWriters> failures) {
+                Assertions.assertEquals(0, failedLoad.size(), "from " + classes.size() + " failed to produce valid bytecode " + failedLoad.size() + ": " + keySetToString(failedLoad, getClassesRoot()));
+            }
+        };
+        tryAll(classes, failedLoad, passedLoad, loadClass);
+    }
+
+    public static String keySetToString(Map<File, ThreeStringWriters> failedJdis, File classesRoot) {
+        return failedJdis.keySet().stream().map(f -> f.getAbsolutePath().replaceFirst(classesRoot.getAbsolutePath(), "")).collect(Collectors.joining(", "));
+    }
+
+    private void tryAll(List<File> classes, Map<File, ThreeStringWriters> failed, Map<File, ThreeStringWriters> passed, AsmToolsExecutable ex) throws IOException {
+        for (File clazz : classes) {
+            ThreeStringWriters outs = new ThreeStringWriters();
+            int i = ex.run(outs, clazz);
+            outs.flush();
+            if (i != 0) {
+                Object o = failed.put(clazz, outs);
+                Assertions.assertNull(o, " duplicated class - " + o);
+                continue;
+            }
+            Object o = passed.put(clazz, outs);
+            Assertions.assertNull(o, " duplicated class - " + o);
+        }
+        for (Map.Entry<File, ThreeStringWriters> failure : failed.entrySet().stream().sorted(new Comparator<Map.Entry<File, ThreeStringWriters>>() {
+            @Override
+            public int compare(Map.Entry<File, ThreeStringWriters> t0, Map.Entry<File, ThreeStringWriters> t1) {
+                return t0.getKey().compareTo(t1.getKey());
+            }
+        }).collect(Collectors.toList())) {
+            System.err.println(failure.getKey());
+            System.err.println(failure.getValue().getErrorBos());
+            System.err.println(failure.getValue().getLoggerBos());
+            System.err.println(failure.getValue().getToolBos());
+        }
+    }
+
+    private static List<File> findClasses(File classesRoot) throws IOException {
+        List<File> classes = new ArrayList<>();
+        Files.walkFileTree(classesRoot.toPath(), new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path path, BasicFileAttributes basicFileAttributes) throws IOException {
+                if (path.toString().endsWith(".class")) {
+                    classes.add(path.toFile().getAbsoluteFile());
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+        Assertions.assertNotEquals(0, classes.size(), "There must be more then 0 class compiled in " + classesRoot + " before running this tests!");
+        Collections.sort(classes);
+        return classes;
+    }
+
+    public String getDecompiledClass(File clazz) {
+        return passedJdis.get(clazz).getToolBos();
+    }
+
+    public File getCompileDir() {
+        return compileDir;
+    }
+
+    public File getClassesRoot() {
+        return classProvider.getClassesRoot();
+    }
+
+    public static void createMetadata(ThreeStringWriters outs, File clazz, File savedAsm, File compileDir, File classesRoot) {
+        outs.getToolOutput().println("Orig: " + clazz.getAbsolutePath());
+        outs.getToolOutput().println("To: " + compileDir.getAbsolutePath());
+        outs.getToolOutput().println("Base: " + classesRoot.getAbsolutePath());
+        outs.getToolOutput().println("From: " + savedAsm.getAbsolutePath());
+    }
+
+    public static File saveDecompiledCode(String body, String tmpPRefix) throws IOException {
+        File savedFresh = File.createTempFile(tmpPRefix, ".java");
+        Files.writeString(savedFresh.toPath(), body);
+        savedFresh.deleteOnExit();
+        return savedFresh;
+    }
+
+    public static class SearchingClassProvider implements ClassProvider {
+        private final File root;
+
+        public SearchingClassProvider(File root) {
+            this.root = root.getAbsoluteFile();
+        }
+
+        @Override
+        public File getClassesRoot() {
+            return root;
+        }
+
+        @Override
+        public List<File> getClasses() throws IOException {
+            return findClasses(root);
+        }
+    }
+
+    public interface ClassProvider {
+
+        File getClassesRoot();
+
+        List<File> getClasses() throws IOException;
+    }
+
+    public interface AsmToolsExecutable {
+        
+        int run(ThreeStringWriters out, File clazz) throws IOException;
+
+        void ensure(List<File> all, Map<File, ThreeStringWriters> failures);
+    }
+
+}

--- a/test/org/openjdk/asmtools/jdec/JdecJcod.java
+++ b/test/org/openjdk/asmtools/jdec/JdecJcod.java
@@ -1,0 +1,75 @@
+package org.openjdk.asmtools.jdec;
+
+import org.junit.jupiter.api.Assertions;
+import org.openjdk.asmtools.BruteForceHelper;
+import org.openjdk.asmtools.ThreeStringWriters;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+class JdecJcod {
+
+    private final boolean g;
+    private final BruteForceHelper worker;
+
+    public JdecJcod(boolean g, BruteForceHelper worker) {
+        this.g = g;
+        this.worker = worker;
+    }
+
+    public void run() throws IOException {
+        BruteForceHelper.AsmToolsExecutable jdec = new BruteForceHelper.AsmToolsExecutable() {
+            @Override
+            public int run(ThreeStringWriters outs, File clazz) throws IOException {
+                Main decoder;
+                if (g) {
+                    decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), "-g", clazz.getAbsolutePath());
+                } else {
+                    decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), clazz.getAbsolutePath());
+                }
+                return decoder.decode();
+            }
+
+            @Override
+            public void ensure(List<File> all, Map<File, ThreeStringWriters> failures) {
+                String gs = "";
+                if (g) {
+                    gs = "with -g ";
+                }
+                Assertions.assertEquals(0, failures.size(), "from " + all.size() + "(" + worker.getClassesRoot() + ") failed to decode " + gs + failures.size() + ": " + BruteForceHelper.keySetToString(failures, worker.getClassesRoot()));
+            }
+        };
+        BruteForceHelper.AsmToolsExecutable jasm = new JasmToolExecutable(worker, g);
+        worker.work(jdec, jasm);
+    }
+
+    private static class JasmToolExecutable implements BruteForceHelper.AsmToolsExecutable {
+        private final BruteForceHelper worker;
+        private final String g;
+
+        public JasmToolExecutable(BruteForceHelper worker, boolean g) {
+            this.worker = worker;
+            if (g) {
+                this.g = " (from -g decode) ";
+            } else {
+                this.g = "";
+            }
+        }
+
+        @Override
+        public int run(ThreeStringWriters outs, File clazz) throws IOException {
+            File savedCode = BruteForceHelper.saveDecompiledCode(worker.getDecompiledClass(clazz), "JdecJcodWorks");
+            org.openjdk.asmtools.jcoder.Main coder = new org.openjdk.asmtools.jcoder.Main(outs.getErrorOutput(), outs.getLoggerOutput(), savedCode.getAbsolutePath(), "-d", worker.getCompileDir().getAbsolutePath());
+            BruteForceHelper.createMetadata(outs, clazz, savedCode, worker.getCompileDir(), worker.getClassesRoot());
+            return coder.compile();
+        }
+
+        @Override
+        public void ensure(List<File> all, Map<File, ThreeStringWriters> failures) {
+            Assertions.assertEquals(0, failures.size(), "from " + all.size() + " failed to encode " + g + " to (" + worker.getCompileDir() + ") " + failures.size() + ": " + BruteForceHelper.keySetToString(failures, worker.getClassesRoot()));
+        }
+    }
+}
+

--- a/test/org/openjdk/asmtools/jdec/JdecJcodTest.java
+++ b/test/org/openjdk/asmtools/jdec/JdecJcodTest.java
@@ -1,0 +1,24 @@
+package org.openjdk.asmtools.jdec;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.asmtools.BruteForceHelper;
+
+import java.io.IOException;
+
+
+class JdecJcodTest {
+
+    @Test
+    public void jdecJcodAllDecompileCompileAndLoad() throws IOException {
+        BruteForceHelper worker = new BruteForceHelper();
+        new JdecJcod(false, worker).run();
+    }
+
+    @Test
+    public void jdecGJcodAllDecompileCompileAndLoad() throws IOException {
+        BruteForceHelper worker = new BruteForceHelper();
+        new JdecJcod(true, worker).run();
+
+    }
+}
+

--- a/test/org/openjdk/asmtools/jdis/JdisJasm.java
+++ b/test/org/openjdk/asmtools/jdis/JdisJasm.java
@@ -1,0 +1,76 @@
+package org.openjdk.asmtools.jdis;
+
+import org.junit.jupiter.api.Assertions;
+import org.openjdk.asmtools.BruteForceHelper;
+import org.openjdk.asmtools.ThreeStringWriters;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+class JdisJasm {
+
+    private final boolean g;
+    private final BruteForceHelper worker;
+
+    public JdisJasm(boolean g, BruteForceHelper worker) {
+        this.g = g;
+        this.worker = worker;
+    }
+
+    public void run() throws IOException {
+        BruteForceHelper.AsmToolsExecutable jdis = new BruteForceHelper.AsmToolsExecutable() {
+            @Override
+            public int run(ThreeStringWriters outs, File clazz) throws IOException {
+                Main disassem;
+                if (g) {
+                    disassem = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), "-g", clazz.getAbsolutePath());
+                } else {
+                    disassem = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), clazz.getAbsolutePath());
+                }
+                return disassem.disasm();
+            }
+
+            @Override
+            public void ensure(List<File> all, Map<File, ThreeStringWriters> failures) {
+                String gs = "";
+                if (g) {
+                    gs = "with -g ";
+                }
+                Assertions.assertEquals(0, failures.size(), "from " + all.size() + "(" + worker.getClassesRoot() + ") failed to disassemble " + gs + failures.size() + ": " + BruteForceHelper.keySetToString(failures, worker.getClassesRoot()));
+            }
+        };
+        BruteForceHelper.AsmToolsExecutable jasm = new JasmToolExecutable(worker, g);
+        worker.work(jdis, jasm);
+    }
+
+    private static class JasmToolExecutable implements BruteForceHelper.AsmToolsExecutable {
+        private final BruteForceHelper worker;
+        private final String g;
+
+        public JasmToolExecutable(BruteForceHelper worker, boolean g) {
+            this.worker = worker;
+            if (g) {
+                this.g = " (from -g disasm) ";
+            } else {
+                this.g = "";
+            }
+        }
+
+        @Override
+        public int run(ThreeStringWriters outs, File clazz) throws IOException {
+            File savedAsm = BruteForceHelper.saveDecompiledCode(worker.getDecompiledClass(clazz), "JdisJasmWorks");
+            org.openjdk.asmtools.jasm.Main asm = new org.openjdk.asmtools.jasm.Main(outs.getErrorOutput(), outs.getLoggerOutput(), savedAsm.getAbsolutePath(), "-d", worker.getCompileDir().getAbsolutePath());
+            BruteForceHelper.createMetadata(outs, clazz, savedAsm, worker.getCompileDir(), worker.getClassesRoot());
+            return asm.compile();
+        }
+
+        @Override
+        public void ensure(List<File> all, Map<File, ThreeStringWriters> failures) {
+            //three classes now fails, they will fail again in attempt to be loaded on NPE
+            Assertions.assertEquals(0, failures.size(), "from " + all.size() + " failed to assemble " + g + " to (" + worker.getCompileDir() + ") " + failures.size() + ": " + BruteForceHelper.keySetToString(failures, worker.getClassesRoot()));
+        }
+    }
+}
+

--- a/test/org/openjdk/asmtools/jdis/JdisJasmTest.java
+++ b/test/org/openjdk/asmtools/jdis/JdisJasmTest.java
@@ -1,0 +1,23 @@
+package org.openjdk.asmtools.jdis;
+
+import org.junit.jupiter.api.Test;
+import org.openjdk.asmtools.BruteForceHelper;
+
+import java.io.IOException;
+
+class JdisJasmTest {
+
+    @Test
+    public void jdisJasmAllDecompileCompileAndLoad() throws IOException {
+        BruteForceHelper worker = new BruteForceHelper();
+        new JdisJasm(false, worker).run();
+    }
+
+    @Test
+    public void jdisGJasmAllDecompileCompileAndLoad() throws IOException {
+        BruteForceHelper worker = new BruteForceHelper();
+        new JdisJasm(true, worker).run();
+
+    }
+}
+


### PR DESCRIPTION
Added two set of tests
jdec->jcoder->load
jdis->jasm->load
Both in two variants, with -g, and without

Both jdec->jcoder->load works fine
Both jdis->jasm->load now fails on three files from 278:
 /org/openjdk/asmtools/jasm/JasmEnvironment$InputFile.class, /org/openjdk/asmtools/jcoder/Jcoder.class, /org/openjdk/asmtools/jasm/Parser.class
Fail looks valid.

Unluckily, the issue where -g disassembled and back assembled
com.google.gson.Gson produce invalid bytecode was not hit

The class BruteForceHelper is reusable for any set of classes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/asmtools pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/27.diff">https://git.openjdk.org/asmtools/pull/27.diff</a>

</details>
