### PR TITLE
7903249: asmtools build produces javadoc warning caused by invalid usage of tag &

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ The GNU General Public License (GPL)
 Version 2, June 1991
 
 Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 Everyone is permitted to copy and distribute verbatim copies of this license
 document, but changing it is not allowed.
@@ -287,8 +287,8 @@ pointer to where the full notice is found.
     more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc., 59
-    Temple Place, Suite 330, Boston, MA 02111-1307 USA
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 Also add information on how to contact you by electronic and paper mail.
 

--- a/src/org/openjdk/asmtools/jasm/TypeAnnotationTypes.java
+++ b/src/org/openjdk/asmtools/jasm/TypeAnnotationTypes.java
@@ -25,7 +25,7 @@ package org.openjdk.asmtools.jasm;
 import java.io.PrintWriter;
 
 /**
- * Type annotation types: target_type, target_info &amp;&amp; target_path
+ * Type annotation types: target_type, target_info and target_path
  */
 public class TypeAnnotationTypes {
 
@@ -94,7 +94,7 @@ public class TypeAnnotationTypes {
         @Override
         public String toString() {
             // Chapter 4.7.20.2 The type_path structure
-            // if the value of the type_path_kind is 0,1, or 2, thebn the value of the
+            // if the value of the type_path_kind is 0,1, or 2, then the value of the
             // type_argument_index item is 0.
             return kind.parseKey() +  ( kind.tag == 3 ?
                     JasmTokens.Token.LBRACE.parseKey() + typeArgumentIndex + JasmTokens.Token.RBRACE.parseKey() :

--- a/src/org/openjdk/asmtools/jdis/ClassData.java
+++ b/src/org/openjdk/asmtools/jdis/ClassData.java
@@ -67,7 +67,7 @@ public class ClassData extends MemberData {
     protected ConstantPool pool;
 
     // -----------------------------
-    // Interfaces,Fields,Methods && Attributes
+    // Interfaces,Fields,Methods and Attributes
     // -----------------------------
     // The interfaces this class implements
     protected int[] interfaces;
@@ -526,4 +526,3 @@ printSugar:
     }
 
 }// end class ClassData
-


### PR DESCRIPTION
This is the fix for: https://bugs.openjdk.org/browse/CODETOOLS-7903249

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903249](https://bugs.openjdk.org/browse/CODETOOLS-7903249): asmtools build produces javadoc warning caused by invalid usage of tag &


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/asmtools pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/29.diff">https://git.openjdk.org/asmtools/pull/29.diff</a>

</details>
