### PR TITLE
7903248: jasm: FieldData.ConstantValue holds undefined reference to CP while writing fields to a class

### DIFF
--- a/build/productinfo.properties
+++ b/build/productinfo.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,5 +27,5 @@ PRODUCT_NAME        = asmtools
 PRODUCT_JAR_NAME    = asmtools.jar
 PRODUCT_VERSION     = 8.0
 PRODUCT_MILESTONE   = ea
-PRODUCT_BUILDNUMBER = 01
+PRODUCT_BUILDNUMBER = 02
 PRODUCT_NAME_LONG   = Java Assembler Tools

--- a/src/org/openjdk/asmtools/jasm/CPXAttr.java
+++ b/src/org/openjdk/asmtools/jasm/CPXAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ class CPXAttr extends AttrData {
 
     public CPXAttr(ConstantPool pool, EAttribute attribute, ConstCell<?> cell) {
         super(pool, attribute);
-        this.cell = classifyConstCell(cell);
+        this.cell = classifyConstCell(pool, cell);
     }
 
     public int attrLength() {
@@ -47,4 +47,3 @@ class CPXAttr extends AttrData {
         out.writeShort(cell.cpIndex);
     }
 } // end class CPXAttr
-

--- a/src/org/openjdk/asmtools/jasm/ClassArrayAttr.java
+++ b/src/org/openjdk/asmtools/jasm/ClassArrayAttr.java
@@ -55,7 +55,7 @@ public class ClassArrayAttr extends AttrData {
     public ClassArrayAttr(ConstantPool pool, EAttribute attribute, List<ConstCell> constCellList) {
         super(pool, attribute);
         for (ConstCell<?> cell : constCellList) {
-            this.classes.add(classifyConstCell(cell));
+            this.classes.add(classifyConstCell(pool, cell));
         }
     }
 

--- a/src/org/openjdk/asmtools/jasm/CodeAttr.java
+++ b/src/org/openjdk/asmtools/jasm/CodeAttr.java
@@ -85,7 +85,7 @@ class CodeAttr extends AttrData {
         this.max_stack = max_stack;
         this.max_locals = max_locals;
         this.locVarSlots = new ArrayList<>(Collections.nCopies(max_locals != null ? max_locals.value() : paramCount, VACANT));
-        lastInstr = zeroInstr = new Instr(pool, environment);
+        lastInstr = zeroInstr = new Instr(methodData.pool, environment);
         exceptionTable = new DataVector<>(0); // TrapData
         attributes = new DataVector<>();
         if (environment.getVerboseFlag()) {
@@ -320,7 +320,7 @@ class CodeAttr extends AttrData {
 
     // Instructions
     void addInstr(int mnenoc_pos, Opcode opcode, Indexer arg, Object arg2) {
-        Instr newInstr = new Instr(pool, environment).set(curPC, environment.getPosition(), opcode, arg, arg2);
+        Instr newInstr = new Instr(methodData.pool, environment).set(curPC, environment.getPosition(), opcode, arg, arg2);
         lastInstr.next = newInstr;
         lastInstr = newInstr;
         int len = opcode.length();
@@ -426,4 +426,3 @@ class CodeAttr extends AttrData {
     }
 
 } // end CodeAttr
-

--- a/src/org/openjdk/asmtools/jasm/DataVectorAttr.java
+++ b/src/org/openjdk/asmtools/jasm/DataVectorAttr.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 /**
  * Container for attributes having inline tables:
@@ -72,7 +73,13 @@ class DataVectorAttr<T extends DataWriter> extends AttrData implements Iterable<
     }
 
     public void add(T element) {
-        elements.add(element);
+        if (element != null)
+            elements.add(element);
+    }
+
+    public DataVectorAttr<T> addAll(Stream<T> s) {
+        s.filter(e->e != null).forEach(elements::add);
+        return this;
     }
 
     public void put(int i, T element) {
@@ -84,6 +91,10 @@ class DataVectorAttr<T extends DataWriter> extends AttrData implements Iterable<
     public void replaceAll(Collection<T> collection) {
         elements.clear();
         elements.addAll(collection);
+    }
+
+    public ArrayList<T> getElements() {
+        return elements;
     }
 
     @Override

--- a/src/org/openjdk/asmtools/jasm/FieldData.java
+++ b/src/org/openjdk/asmtools/jasm/FieldData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ class FieldData extends MemberData<JasmEnvironment> {
 
     /* FieldData Fields */
     private ConstantPool.ConstValue_FieldRef fieldRef;
-    private AttrData initValue;
+    private AttrData initialValue;
 
     public FieldData(ClassData classData, int access, ConstantPool.ConstValue_FieldRef fieldRef) {
         super(classData.pool, classData.getEnvironment(), access);
@@ -48,13 +48,17 @@ class FieldData extends MemberData<JasmEnvironment> {
         return fieldRef;
     }
 
-    public void SetValue(ConstCell<?>  cell) {
-        initValue = new CPXAttr(pool, EAttribute.ATT_ConstantValue, cell);
+    public void SetInitialValue(ConstCell<?>  cell) {
+        initialValue = new CPXAttr(pool, EAttribute.ATT_ConstantValue, cell);
+    }
+
+    public AttrData getInitialValue() {
+        return initialValue;
     }
 
     @Override
     protected DataVector getAttrVector() {
-        return getDataVector(initValue, syntheticAttr, deprecatedAttr, signatureAttr);
+        return getDataVector(initialValue, syntheticAttr, deprecatedAttr, signatureAttr);
     }
 
     public void write(CheckedDataOutputStream out) throws IOException, Parser.CompilerError {
@@ -65,4 +69,3 @@ class FieldData extends MemberData<JasmEnvironment> {
         attrs.write(out);
     }
 } // end FieldData
-

--- a/src/org/openjdk/asmtools/jasm/ModuleAttr.java
+++ b/src/org/openjdk/asmtools/jasm/ModuleAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,10 +61,10 @@ class ModuleAttr extends AttrData {
     ModuleAttr(ClassData classData) {
         super(classData.pool, EAttribute.ATT_Module);
         builder = new ModuleContent.Builder();
-        findUTF8Cell = targetType -> pool.findUTF8Cell(targetType);
-        findClassCell = targetType -> pool.findClassCell(targetType);
-        findModuleCell = targetType -> pool.findModuleCell(targetType);
-        findPackageCell = targetType -> pool.findPackageCell(targetType);
+        findUTF8Cell = targetType -> classData.pool.findUTF8Cell(targetType);
+        findClassCell = targetType -> classData.pool.findClassCell(targetType);
+        findModuleCell = targetType -> classData.pool.findModuleCell(targetType);
+        findPackageCell = targetType -> classData.pool.findPackageCell(targetType);
     }
 
     void openModule() {

--- a/src/org/openjdk/asmtools/jasm/Parser.java
+++ b/src/org/openjdk/asmtools/jasm/Parser.java
@@ -715,7 +715,7 @@ class Parser extends ParseBase {
             // Parse the optional initializer
             if (scanner.token == ASSIGN) {
                 scanner.scan();
-                fld.SetValue(cpParser.parseConstRef(null));
+                fld.SetInitialValue(cpParser.parseConstRef(null));
             }
 
             // If the next scanner.token is a comma, then there is more
@@ -1976,8 +1976,8 @@ class Parser extends ParseBase {
             String sourceFileName = environment.getSimpleInputFileName();
             String sourceName = sourceFileName.substring(0, sourceFileName.indexOf('.'));
             classData.sourceFileNameAttr = new SourceFileAttr(this.classData.pool, sourceFileName).
-                    updateIfFound(name ->
-                            name.startsWith(sourceName) &&
+                    updateIfFound( this.classData.pool,
+                            name -> name.startsWith(sourceName) &&
                                     StringUtils.contains.apply(name, List.of(".java", ".jcod", ".jasm", ".class"))
                     );
         } else {
@@ -1999,7 +1999,7 @@ class Parser extends ParseBase {
             pool.fixRefsInPool();
             String sourceName = environment.getSimpleInputFileName();
             classData.sourceFileNameAttr = new SourceFileAttr(this.classData.pool, sourceName).
-                    updateIfFound(name -> name.contains("package-info."));
+                    updateIfFound(this.classData.pool, name -> name.contains("package-info."));
         } else {
             classData.sourceFileNameAttr = new CPXAttr(pool,
                     EAttribute.ATT_SourceFile,
@@ -2019,7 +2019,7 @@ class Parser extends ParseBase {
             pool.fixRefsInPool();
             String sourceName = environment.getSimpleInputFileName();
             classData.sourceFileNameAttr = new SourceFileAttr(this.classData.pool, sourceName).
-                    updateIfFound(name -> name.contains("module-info."));
+                    updateIfFound(this.classData.pool, name -> name.contains("module-info."));
         } else {
             classData.sourceFileNameAttr = new CPXAttr(pool,
                     EAttribute.ATT_SourceFile,

--- a/src/org/openjdk/asmtools/jasm/SourceFileAttr.java
+++ b/src/org/openjdk/asmtools/jasm/SourceFileAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class SourceFileAttr extends AttrData {
      * If such UTF8 string exists then replaces it with a new source file name
      * otherwise creates a new UTF8 cell to fulfill Source File Attribute
      */
-    public SourceFileAttr updateIfFound(Function<String, Boolean> rule) {
+    public SourceFileAttr updateIfFound(ConstantPool pool, Function<String, Boolean> rule) {
         sourceFileNameCell = pool.lookupUTF8Cell(rule);
         if( sourceFileNameCell != null ) {
             sourceFileNameCell.ref.value = sourceFileName;

--- a/src/org/openjdk/asmtools/jasm/TypeAnnotationTypes.java
+++ b/src/org/openjdk/asmtools/jasm/TypeAnnotationTypes.java
@@ -22,8 +22,6 @@
  */
 package org.openjdk.asmtools.jasm;
 
-import java.io.PrintWriter;
-
 /**
  * Type annotation types: target_type, target_info and target_path
  */

--- a/src/org/openjdk/asmtools/jdis/AnnotationData.java
+++ b/src/org/openjdk/asmtools/jdis/AnnotationData.java
@@ -27,12 +27,12 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
-public class AnnotationData<T extends MemberData> extends MemberData {
+import static org.openjdk.asmtools.jdis.MemberData.AnnotationElementState.*;
 
+public class AnnotationData<T extends MemberData> extends MemberData {
     protected String visibleAnnotationToken = "@+";
     protected String invisibleAnnotationToken = "@-";
     protected String dataName = "AnnotationData";
-
     private final ArrayList<AnnotationElement> annotationElements = new ArrayList<>();
 
     private int type_cpx = 0;       //an index into the constant pool indicating the annotation type for this annotation.
@@ -89,7 +89,7 @@ public class AnnotationData<T extends MemberData> extends MemberData {
         } else {
             switch (getAnnotationElementState()) {
                 case HAS_DEFAULT_VALUE -> {
-                    println("{");
+                    println(" {");
                     printBodyOfDefaultData();
                     print(" }");
                 }
@@ -112,7 +112,7 @@ public class AnnotationData<T extends MemberData> extends MemberData {
         int prefixLength = getCommentOffset();
         for (AnnotationElement annotationElement : annotationElements) {
             print(enlargedIndent(prefixLength));
-            annotationElement.setElementState(this.getAnnotationElementState());
+            annotationElement.setElementState(RIGHT_OPERAND);
             annotationElement.print();
         }
     }
@@ -149,4 +149,3 @@ public class AnnotationData<T extends MemberData> extends MemberData {
         return annotationElements.isEmpty();
     }
 }
-

--- a/src/org/openjdk/asmtools/jdis/AnnotationElement.java
+++ b/src/org/openjdk/asmtools/jdis/AnnotationElement.java
@@ -35,8 +35,7 @@ import static org.openjdk.asmtools.asmutils.StringUtils.Utf8ToString;
 import static org.openjdk.asmtools.asmutils.StringUtils.isPrintableChar;
 import static org.openjdk.asmtools.jasm.ClassFileConst.AnnotationElementType;
 import static org.openjdk.asmtools.jasm.ClassFileConst.getAnnotationElementType;
-import static org.openjdk.asmtools.jdis.MemberData.AnnotationElementState.HAS_DEFAULT_VALUE;
-import static org.openjdk.asmtools.jdis.MemberData.AnnotationElementState.INLINED_ELEMENT;
+import static org.openjdk.asmtools.jdis.MemberData.AnnotationElementState.*;
 
 /**
  * Base class of all AnnotationElement entries
@@ -116,6 +115,7 @@ public class AnnotationElement<T extends MemberData<T>> extends MemberData<T> {
             if (((Array_AnnotationValue<?>) value).annotationValues.size() == 0) {
                 print("{ }");
             } else {
+                println().print(getIndentString());
                 value.print();
                 printIndent("}");
             }
@@ -202,8 +202,11 @@ public class AnnotationElement<T extends MemberData<T>> extends MemberData<T> {
 
         @Override
         public void print() {
-            if (getAnnotationElementState() == HAS_DEFAULT_VALUE) {
+            AnnotationElementState state = getAnnotationElementState();
+            if ( state == HAS_DEFAULT_VALUE) {
                 print(DEFAULT_VALUE_PREFIX + "%s }", stringVal());
+            } else if( state == RIGHT_OPERAND) {
+                print(" %s }", stringVal());
             } else {
                 print(stringVal());
             }
@@ -315,26 +318,27 @@ public class AnnotationElement<T extends MemberData<T>> extends MemberData<T> {
 
         public void printDefaultAnnotationElement(int count, int ItemsPerLine) throws IOException {
             int i = 0, lineIndent = getIndent(annotationValues.get(0));
-            print(DEFAULT_VALUE_PREFIX + "{ ");
+            println(DEFAULT_VALUE_PREFIX + "{ ");
+            printPadLeft(INDENT_STRING, INDENT_OFFSET*2);
             for (AnnotationValue<T> annotationValue : annotationValues) {
                 annotationValue.setElementState(INLINED_ELEMENT);
                 annotationValue.setCommentOffset(lineIndent);
                 if (annotationValue instanceof Annotation_AnnotationValue ||
                         annotationValue instanceof CPX_AnnotationValue) {
                     if (i % ItemsPerLine == 0 && i != 0)
-                        print(enlargedIndent(lineIndent));
+                        printPadLeft(INDENT_STRING, INDENT_OFFSET*2);
                 }
                 annotationValue.print(); // entry
                 if (i < count - 1)
                     print("," + (i % ItemsPerLine == (ItemsPerLine - 1) ? System.lineSeparator() : " "));
                 i++;
             }
-            print(" } }");
+            println(" }").print("  }");
         }
 
         public void printAnnotationElement(int count) throws IOException {
             int i = 0;
-            toolOutput.println("{");
+            println("{");
             for (AnnotationValue<T> annotationValue : annotationValues) {
                 annotationValue.setTheSame(this);
                 if (annotationValue instanceof CPX_AnnotationValue) {

--- a/src/org/openjdk/asmtools/jdis/FieldData.java
+++ b/src/org/openjdk/asmtools/jdis/FieldData.java
@@ -97,12 +97,13 @@ public class FieldData extends MemberData<ClassData> {
         // Print annotations first
         super.printAnnotations();
         // print field
-        StringBuilder prefix = new StringBuilder(getIndentString()).append(EModifier.asKeywords(access, ClassFileContext.FIELD));
+        StringBuilder prefix = new StringBuilder(getIndentString()).
+                append(EModifier.asKeywords(access, ClassFileContext.FIELD));
         // add synthetic, deprecated if necessary
         prefix.append(getPseudoFlagsAsString());
         // field
         prefix.append(JasmTokens.Token.FIELDREF.parseKey()).append(' ');
-        printVar(prefix, (value_cpx != 0) ? (" = ").concat(data.pool.ConstantStrValue(value_cpx)) : null, name_cpx, type_cpx);
+        printVar(prefix, (value_cpx != 0) ? (" = ").concat(data.pool.ConstantStrValue(value_cpx)) : null,
+                name_cpx, type_cpx, value_cpx);
     }
 } // end FieldData
-

--- a/src/org/openjdk/asmtools/jdis/MemberData.java
+++ b/src/org/openjdk/asmtools/jdis/MemberData.java
@@ -58,6 +58,7 @@ public abstract class  MemberData<T extends MemberData> extends Indenter {
         HAS_DEFAULT_VALUE,       // An annotation interface element has a default value
         DEFAULT_STATE,
         PARAMETER_ANNOTATION,
+        RIGHT_OPERAND,
         INLINED_ELEMENT          // An annotation element is element of an annotation element.
     }
 
@@ -168,7 +169,16 @@ public abstract class  MemberData<T extends MemberData> extends Indenter {
         }
     }
 
-    protected void printVar(StringBuilder prefix, String postfix, int name_cpx, int type_cpx) {
+    /**
+     * Prints field or a record component
+     * @param prefix      the field prefix: "private static final Field" or the component prefix: "synthetic Component"
+     * @param postfix     String presentation of the initial value if exists ( = String "ABC" )
+     * @param name_cpx    Field/Component name cpIndex
+     * @param type_cpx    Field/Component type cpIndex
+     * @param value_cpx   either cpIndex of an initial value of a field or 0
+     *                    if it's a component or the field doesn't have an initial value.
+     */
+    protected void printVar(StringBuilder prefix, String postfix, int name_cpx, int type_cpx, int value_cpx) {
 
         Pair<String, String> signInfo = ( signature != null) ?
                 signature.getPrintInfo((i)->pool.inRange(i)) :
@@ -176,14 +186,19 @@ public abstract class  MemberData<T extends MemberData> extends Indenter {
 
         if(printCPIndex) {
             prefix.append('#').append(name_cpx).append(":#").append(type_cpx).append(signInfo.first);
-            if(postfix != null) {
-                prefix.append(postfix);
+            if(value_cpx != 0) {
+                prefix.append(" = #").append(value_cpx);
             }
             prefix.append(';');
             printPadRight(prefix.toString(), getCommentOffset()-1).print(" // ");
-            print( data.pool.getName(name_cpx) + ":" + data.pool.getName(type_cpx) + signInfo.second);
+            print( data.pool.getName(name_cpx) + ":" +
+                    data.pool.getName(type_cpx) +
+                    signInfo.second +
+                    (postfix != null ? postfix : "")) ;
         } else {
-            prefix.append(data.pool.getName(name_cpx)).append(':').append(data.pool.getName(type_cpx)).append(signInfo.second);
+            prefix.append(data.pool.getName(name_cpx)).append(':').
+                    append(data.pool.getName(type_cpx)).
+                    append(signInfo.second);
             if( postfix != null ) {
                 prefix.append(postfix);
             }

--- a/src/org/openjdk/asmtools/jdis/RecordData.java
+++ b/src/org/openjdk/asmtools/jdis/RecordData.java
@@ -133,7 +133,7 @@ public class RecordData extends  MemberData<ClassData> {
             prefix.append(getPseudoFlagsAsString());
             // component
             prefix.append(JasmTokens.Token.COMPONENT.parseKey()).append(' ');
-            printVar(prefix, null, name_cpx, descriptor_cpx);
+            printVar(prefix, null, name_cpx, descriptor_cpx, 0);
         }
     }
 }


### PR DESCRIPTION
This is the fix for https://bugs.openjdk.org/browse/CODETOOLS-7903248. Also it fixes formatting issues in printing of annotations' default values.