### PR TITLE
adding support for stdin

### DIFF
--- a/src/org/openjdk/asmtools/common/CompilerLogger.java
+++ b/src/org/openjdk/asmtools/common/CompilerLogger.java
@@ -23,6 +23,7 @@
 package org.openjdk.asmtools.common;
 
 import org.openjdk.asmtools.asmutils.Pair;
+import org.openjdk.asmtools.common.structure.ToolInput;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -86,10 +87,10 @@ public class CompilerLogger extends ToolLogger implements ILogger {
     }
 
     @Override
-    public void setInputFileName(String inputFileName) throws IOException {
+    public void setInputFileName(ToolInput inputFileName) throws IOException {
         super.setInputFileName(inputFileName);
         fileContent.clear();
-        fileContent.addAll(Files.readAllLines(Paths.get(inputFileName)));
+        fileContent.addAll(inputFileName.readAllLines());
     }
 
     /**

--- a/src/org/openjdk/asmtools/common/CompilerLogger.java
+++ b/src/org/openjdk/asmtools/common/CompilerLogger.java
@@ -23,12 +23,9 @@
 package org.openjdk.asmtools.common;
 
 import org.openjdk.asmtools.asmutils.Pair;
-import org.openjdk.asmtools.common.structure.ToolInput;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.*;
 
 import static java.lang.String.format;

--- a/src/org/openjdk/asmtools/common/Environment.java
+++ b/src/org/openjdk/asmtools/common/Environment.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools.common;
 
+import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.DataInputStream;
@@ -33,6 +34,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * TODO: Replacement for Environment that will replace it.
@@ -45,8 +47,8 @@ public abstract class Environment<T extends ToolLogger> implements ILogger {
 
     T toolLogger;
 
-    // processed input file
-    private String inputFileName;
+    // processed input file or stdin
+    private ToolInput inputFileName;
     // checks output verbosity
     private boolean verboseFlag;
 
@@ -60,7 +62,7 @@ public abstract class Environment<T extends ToolLogger> implements ILogger {
         this.toolLogger = (T) builder.toolLogger;
     }
 
-    public void setInputFile(String inputFileName) throws IOException, URISyntaxException {
+    public void setInputFile(ToolInput inputFileName) throws IOException, URISyntaxException {
         this.inputFileName = inputFileName;
         toolLogger.setInputFileName(inputFileName);
     }
@@ -79,31 +81,14 @@ public abstract class Environment<T extends ToolLogger> implements ILogger {
 
     public String getSimpleInputFileName() { return toolLogger.getSimpleInputFileName(); }
 
-    public String getInputFileName() { return inputFileName; }
+    public ToolInput getInputFile() { return inputFileName; }
 
     /**
      * @return DataInputStream or null if the method can't read a file
      */
     protected DataInputStream getDataInputStream() throws URISyntaxException, IOException {
         Objects.requireNonNull(this.inputFileName, "Input file name should be defined.");
-        try {
-            return new DataInputStream(new FileInputStream(this.inputFileName));
-        } catch (IOException ex) {
-            if (this.inputFileName.matches("^[A-Za-z]+:.*")) {
-                try {
-                    final URI uri = new URI(this.inputFileName);
-                    final URL url = uri.toURL();
-                    final URLConnection conn = url.openConnection();
-                    conn.setUseCaches(false);
-                    return new DataInputStream(conn.getInputStream());
-                } catch (URISyntaxException | IOException exception) {
-                    error("err.cannot.read", this.inputFileName);
-                    throw exception;
-                }
-            } else {
-                throw ex;
-            }
-        }
+        return inputFileName.getDataInputStream(Optional.of(this));
     }
 
     @Override

--- a/src/org/openjdk/asmtools/common/Environment.java
+++ b/src/org/openjdk/asmtools/common/Environment.java
@@ -22,17 +22,12 @@
  */
 package org.openjdk.asmtools.common;
 
-import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.DataInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.Objects;
 import java.util.Optional;
 

--- a/src/org/openjdk/asmtools/common/Environment.java
+++ b/src/org/openjdk/asmtools/common/Environment.java
@@ -82,7 +82,7 @@ public abstract class Environment<T extends ToolLogger> implements ILogger {
      * @return DataInputStream or null if the method can't read a file
      */
     protected DataInputStream getDataInputStream() throws URISyntaxException, IOException {
-        Objects.requireNonNull(this.inputFileName, "Input file name should be defined.");
+        Objects.requireNonNull(this.inputFileName, "Input must be defined.");
         return inputFileName.getDataInputStream(Optional.of(this));
     }
 

--- a/src/org/openjdk/asmtools/common/Tool.java
+++ b/src/org/openjdk/asmtools/common/Tool.java
@@ -25,11 +25,13 @@ package org.openjdk.asmtools.common;
 
 import java.io.File;
 import java.io.PrintWriter;
+import java.util.ArrayList;
 
 public abstract class Tool<T extends Environment<? extends ToolLogger>> {
 
     // private final long tm = System.currentTimeMillis();
 
+    protected final ArrayList<ToolInput> fileList = new ArrayList<>();
     protected T environment;
 
     protected Tool(PrintWriter toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {

--- a/src/org/openjdk/asmtools/common/ToolInput.java
+++ b/src/org/openjdk/asmtools/common/ToolInput.java
@@ -1,7 +1,4 @@
-package org.openjdk.asmtools.common.structure;
-
-import org.openjdk.asmtools.common.Environment;
-import org.openjdk.asmtools.jdis.ClassData;
+package org.openjdk.asmtools.common;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;

--- a/src/org/openjdk/asmtools/common/ToolLogger.java
+++ b/src/org/openjdk/asmtools/common/ToolLogger.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools.common;
 
+import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.IOException;
@@ -67,9 +68,9 @@ public class ToolLogger implements ILogger {
         return i18n.getString(id, args);
     }
 
-    public void setInputFileName(String inputFileName) throws IOException {
-        this.inputFileName = inputFileName;
-        this.simpleInputFileName = Paths.get(inputFileName).getFileName().toString();
+    public void setInputFileName(ToolInput inputFileName) throws IOException {
+        this.inputFileName = inputFileName.getFileName();
+        this.simpleInputFileName = Paths.get(inputFileName.getFileName()).getFileName().toString();
         // content of the input file will be loaded only if the file will be parsed by jasm/jcoder
     }
 

--- a/src/org/openjdk/asmtools/common/ToolLogger.java
+++ b/src/org/openjdk/asmtools/common/ToolLogger.java
@@ -22,7 +22,6 @@
  */
 package org.openjdk.asmtools.common;
 
-import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.IOException;

--- a/src/org/openjdk/asmtools/common/structure/ToolInput.java
+++ b/src/org/openjdk/asmtools/common/structure/ToolInput.java
@@ -24,8 +24,6 @@ public interface ToolInput {
 
     String getFileName();
 
-    void provide(ClassData classData) throws IOException;
-
     DataInputStream getDataInputStream(Optional<Environment> logger) throws URISyntaxException, IOException;
 
     Collection<String> readAllLines() throws IOException;
@@ -40,11 +38,6 @@ public interface ToolInput {
         @Override
         public String getFileName() {
             return file;
-        }
-
-        @Override
-        public void provide(ClassData classData) throws IOException {
-            classData.read(file);
         }
 
         public Collection<String> readAllLines() throws IOException {
@@ -104,13 +97,6 @@ public interface ToolInput {
         public String getFileName() {
             //get parent is used
             return "stdin/in";
-        }
-
-        @Override
-        public void provide(ClassData classData) throws IOException {
-            try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes))) {
-                classData.read(dis, Paths.get(getFileName()));
-            }
         }
 
         @Override

--- a/src/org/openjdk/asmtools/common/structure/ToolInput.java
+++ b/src/org/openjdk/asmtools/common/structure/ToolInput.java
@@ -1,16 +1,34 @@
 package org.openjdk.asmtools.common.structure;
 
+import org.openjdk.asmtools.common.Environment;
 import org.openjdk.asmtools.jdis.ClassData;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Optional;
 
 public interface ToolInput {
 
     String getFileName();
 
     void provide(ClassData classData) throws IOException;
+
+    DataInputStream getDataInputStream(Optional<Environment> logger) throws URISyntaxException, IOException;
+
+    Collection<String> readAllLines() throws IOException;
 
     public static class FileInput implements  ToolInput {
         private final String file;
@@ -29,6 +47,34 @@ public interface ToolInput {
             classData.read(file);
         }
 
+        public Collection<String> readAllLines() throws IOException {
+            return Files.readAllLines(Paths.get(getFileName()));
+        }
+
+        @Override
+        public DataInputStream getDataInputStream(Optional<Environment> logger) throws URISyntaxException, IOException {
+            try {
+                return new DataInputStream(new FileInputStream(this.getFileName()));
+            } catch (IOException ex) {
+                if (this.getFileName().matches("^[A-Za-z]+:.*")) {
+                    try {
+                        final URI uri = new URI(this.getFileName());
+                        final URL url = uri.toURL();
+                        final URLConnection conn = url.openConnection();
+                        conn.setUseCaches(false);
+                        return new DataInputStream(conn.getInputStream());
+                    } catch (URISyntaxException | IOException exception) {
+                        if (logger.isPresent()){
+                            logger.get().error("err.cannot.read", this.getFileName());
+                        }
+                        throw exception;
+                    }
+                } else {
+                    throw ex;
+                }
+            }
+        }
+
         @Override
         public String toString() {
             return getFileName();
@@ -36,6 +82,23 @@ public interface ToolInput {
     }
 
     public static class StdinInput implements  ToolInput {
+
+        //compilers passes input more then one times, so saving it for reuse;
+        private final byte[] bytes;
+
+        public StdinInput() {
+            try {
+                byte[] buffer = new byte[32 * 1024];
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                int bytesRead;
+                while ((bytesRead = System.in.read(buffer)) > 0) {
+                    baos.write(buffer, 0, bytesRead);
+                }
+                bytes = baos.toByteArray();
+            }catch (Exception ex){
+                throw new RuntimeException(ex);
+            }
+        }
 
         @Override
         public String getFileName() {
@@ -45,7 +108,7 @@ public interface ToolInput {
 
         @Override
         public void provide(ClassData classData) throws IOException {
-            try (DataInputStream dis = new DataInputStream(System.in)) {
+            try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes))) {
                 classData.read(dis, Paths.get(getFileName()));
             }
         }
@@ -53,6 +116,26 @@ public interface ToolInput {
         @Override
         public String toString() {
             return getFileName();
+        }
+
+        @Override
+        public DataInputStream getDataInputStream(Optional<Environment> logger) throws URISyntaxException, IOException {
+            return new DataInputStream(new ByteArrayInputStream(bytes));
+        }
+
+        @Override
+        public Collection<String> readAllLines() throws IOException {
+            ArrayList r = new ArrayList();
+            try(BufferedReader br = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes), "utf-8"))){
+                while(true){
+                    String l = br.readLine();
+                    if (l==null){
+                        break;
+                    }
+                    r.add(l);
+                }
+            };
+            return r;
         }
     }
 }

--- a/src/org/openjdk/asmtools/common/structure/ToolInput.java
+++ b/src/org/openjdk/asmtools/common/structure/ToolInput.java
@@ -1,0 +1,58 @@
+package org.openjdk.asmtools.common.structure;
+
+import org.openjdk.asmtools.jdis.ClassData;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+
+public interface ToolInput {
+
+    String getFileName();
+
+    void provide(ClassData classData) throws IOException;
+
+    public static class FileInput implements  ToolInput {
+        private final String file;
+
+        public FileInput(String file) {
+            this.file = file;
+        }
+
+        @Override
+        public String getFileName() {
+            return file;
+        }
+
+        @Override
+        public void provide(ClassData classData) throws IOException {
+            classData.read(file);
+        }
+
+        @Override
+        public String toString() {
+            return getFileName();
+        }
+    }
+
+    public static class StdinInput implements  ToolInput {
+
+        @Override
+        public String getFileName() {
+            //get parent is used
+            return "stdin/in";
+        }
+
+        @Override
+        public void provide(ClassData classData) throws IOException {
+            try (DataInputStream dis = new DataInputStream(System.in)) {
+                classData.read(dis, Paths.get(getFileName()));
+            }
+        }
+
+        @Override
+        public String toString() {
+            return getFileName();
+        }
+    }
+}

--- a/src/org/openjdk/asmtools/jasm/JasmEnvironment.java
+++ b/src/org/openjdk/asmtools/jasm/JasmEnvironment.java
@@ -25,7 +25,7 @@ package org.openjdk.asmtools.jasm;
 import org.openjdk.asmtools.common.CompilerLogger;
 import org.openjdk.asmtools.common.EMessageKind;
 import org.openjdk.asmtools.common.Environment;
-import org.openjdk.asmtools.common.structure.ToolInput;
+import org.openjdk.asmtools.common.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.DataInputStream;

--- a/src/org/openjdk/asmtools/jasm/JasmEnvironment.java
+++ b/src/org/openjdk/asmtools/jasm/JasmEnvironment.java
@@ -25,6 +25,7 @@ package org.openjdk.asmtools.jasm;
 import org.openjdk.asmtools.common.CompilerLogger;
 import org.openjdk.asmtools.common.EMessageKind;
 import org.openjdk.asmtools.common.Environment;
+import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.DataInputStream;
@@ -44,7 +45,7 @@ public class JasmEnvironment extends Environment<CompilerLogger>  {
     }
 
     @Override
-    public void setInputFile(String inputFileName) throws IOException, URISyntaxException {
+    public void setInputFile(ToolInput inputFileName) throws IOException, URISyntaxException {
         try {
             // content of the jasm input file
             super.setInputFile(inputFileName);

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -48,7 +48,6 @@ public class Main extends JasmTool {
 
     private final CFVersion cfv = new CFVersion();
 
-    private final ArrayList<ToolInput> fileList = new ArrayList<>();
     private File destDir;
 
     // tool options

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -23,7 +23,7 @@
 package org.openjdk.asmtools.jasm;
 
 import org.openjdk.asmtools.common.structure.CFVersion;
-import org.openjdk.asmtools.common.structure.ToolInput;
+import org.openjdk.asmtools.common.ToolInput;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -23,6 +23,7 @@
 package org.openjdk.asmtools.jasm;
 
 import org.openjdk.asmtools.common.structure.CFVersion;
+import org.openjdk.asmtools.common.structure.ToolInput;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +48,7 @@ public class Main extends JasmTool {
 
     private final CFVersion cfv = new CFVersion();
 
-    private final ArrayList<String> fileList = new ArrayList<>();
+    private final ArrayList<ToolInput> fileList = new ArrayList<>();
     private File destDir;
 
     // tool options
@@ -85,7 +86,7 @@ public class Main extends JasmTool {
         // compile all input files
         int rc = OK;
         try {
-            for (String inputFileName : fileList) {
+            for (ToolInput inputFileName : fileList) {
                 environment.setInputFile(inputFileName);
                 Parser parser = new Parser(environment, cfv);
                 // Set hidden options: Parser debug flags
@@ -147,6 +148,10 @@ public class Main extends JasmTool {
                     case "-nowrite" -> noWriteFlag = true;
                     case "-version" -> environment.println(FULL_VERSION);
                     case "-d" -> destDir = setDestDir(++i, argv);
+                    case "-h", "-help" -> {
+                        usage();
+                        System.exit(OK);
+                    }
                     // overrides cf version even if it's defined in the source file.
                     case "-fixcv", "-cv" -> {
                         boolean frozenCFV = (arg.startsWith("-fix"));
@@ -203,14 +208,13 @@ public class Main extends JasmTool {
                             usage();
                             throw new IllegalArgumentException();
                         } else {
-                            fileList.add(argv[i]);
+                            fileList.add(new ToolInput.FileInput(argv[i]));
                         }
                     }
                 }
             }
             if (fileList.size() == 0) {
-                usage();
-                throw new IllegalArgumentException();
+                fileList.add(new ToolInput.StdinInput());
             }
         } catch (IllegalArgumentException iae) {
             if (environment.hasMessages()) {

--- a/src/org/openjdk/asmtools/jasm/i18n.properties
+++ b/src/org/openjdk/asmtools/jasm/i18n.properties
@@ -20,7 +20,8 @@
 # questions.
 info.usage=\
 Usage: java -jar asmtools.jar jasm [options] file.jasm...\n\
-where possible options include:
+if no file.jasm is provided, stdin is used\n\
+possible options include:
 info.opt.d=\
 \     -d <directory>        Specify where to place generated class files
 info.opt.v=\

--- a/src/org/openjdk/asmtools/jcoder/JcoderEnvironment.java
+++ b/src/org/openjdk/asmtools/jcoder/JcoderEnvironment.java
@@ -25,6 +25,7 @@ package org.openjdk.asmtools.jcoder;
 import org.openjdk.asmtools.common.CompilerLogger;
 import org.openjdk.asmtools.common.EMessageKind;
 import org.openjdk.asmtools.common.Environment;
+import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.*;
@@ -41,7 +42,7 @@ public class JcoderEnvironment extends Environment<CompilerLogger> {
     }
 
     @Override
-    public void setInputFile(String inputFileName) throws IOException, URISyntaxException {
+    public void setInputFile(ToolInput inputFileName) throws IOException, URISyntaxException {
         try {
             // content of the jcod input file
             super.setInputFile(inputFileName);

--- a/src/org/openjdk/asmtools/jcoder/JcoderEnvironment.java
+++ b/src/org/openjdk/asmtools/jcoder/JcoderEnvironment.java
@@ -25,7 +25,7 @@ package org.openjdk.asmtools.jcoder;
 import org.openjdk.asmtools.common.CompilerLogger;
 import org.openjdk.asmtools.common.EMessageKind;
 import org.openjdk.asmtools.common.Environment;
-import org.openjdk.asmtools.common.structure.ToolInput;
+import org.openjdk.asmtools.common.ToolInput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.*;

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -44,7 +44,6 @@ import static org.openjdk.asmtools.util.ProductInfo.FULL_VERSION;
  */
 public class Main extends JcoderTool {
 
-    private final ArrayList<ToolInput> fileList = new ArrayList<>(1);
     HashMap<String, String> macros = new HashMap<>(1);
     private File destDir;
     // tool options

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.asmtools.jcoder;
 
-import org.openjdk.asmtools.common.structure.ToolInput;
+import org.openjdk.asmtools.common.ToolInput;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -22,6 +22,8 @@
  */
 package org.openjdk.asmtools.jcoder;
 
+import org.openjdk.asmtools.common.structure.ToolInput;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -42,7 +44,7 @@ import static org.openjdk.asmtools.util.ProductInfo.FULL_VERSION;
  */
 public class Main extends JcoderTool {
 
-    private final ArrayList<String> fileList = new ArrayList<>(1);
+    private final ArrayList<ToolInput> fileList = new ArrayList<>(1);
     HashMap<String, String> macros = new HashMap<>(1);
     private File destDir;
     // tool options
@@ -83,7 +85,7 @@ public class Main extends JcoderTool {
         // compile all input files
         int rc = OK;
         try {
-            for (String inputFileName : fileList) {
+            for (ToolInput inputFileName : fileList) {
                 environment.setInputFile(inputFileName);
                 Jcoder parser = new Jcoder(environment, macros);
                 parser.parseFile();
@@ -140,20 +142,23 @@ public class Main extends JcoderTool {
                     case "-nowrite" -> noWriteFlag = true;
                     case "-ignore" -> ignoreFlag = true;
                     case "-version" -> environment.println(FULL_VERSION);
+                    case "-h", "-help" -> {
+                        usage();
+                        System.exit((OK));
+                    }
                     default -> {
                         if (arg.startsWith("-")) {
                             environment.error("err.invalid_option", arg);
                             usage();
                             throw new IllegalArgumentException();
                         } else {
-                            fileList.add(argv[i]);
+                            fileList.add(new ToolInput.FileInput(argv[i]));
                         }
                     }
                 }
             }
             if (fileList.size() == 0) {
-                usage();
-                throw new IllegalArgumentException();
+                fileList.add(new ToolInput.StdinInput());
             }
         } catch (IllegalArgumentException iae) {
             if (environment.hasMessages()) {

--- a/src/org/openjdk/asmtools/jcoder/i18n.properties
+++ b/src/org/openjdk/asmtools/jcoder/i18n.properties
@@ -20,7 +20,8 @@
 # questions.
 info.usage=\
 Usage: java -jar asmtools.jar jcoder [options] file.jcod...\n\
-where possible options include:
+if no file.jcod is provided, stdin is used\n\
+possible options include:
 info.opt.nowrite=\
 \     -nowrite        Do not write generated class files
 info.opt.ignore=\

--- a/src/org/openjdk/asmtools/jdec/ClassData.java
+++ b/src/org/openjdk/asmtools/jdec/ClassData.java
@@ -32,6 +32,7 @@ import org.openjdk.asmtools.jcoder.JcodTokens;
 
 import java.awt.event.KeyEvent;
 import java.io.*;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -68,10 +69,10 @@ class ClassData {
     /*========================================================*/
     private int indent = 0;
 
-    ClassData(JdecEnvironment environment) throws IOException {
+    ClassData(JdecEnvironment environment) throws IOException, URISyntaxException {
         this.environment = environment;
         //
-        try (DataInputStream dis = new DataInputStream(new FileInputStream(environment.getInputFileName()))) {
+        try (DataInputStream dis = environment.getInputFile().getDataInputStream(Optional.empty())) {
             byte[] buf = new byte[dis.available()];
             if (dis.read(buf) <= 0) {
                 throw new FormatError("err.file.empty", environment.getSimpleInputFileName());
@@ -1132,7 +1133,7 @@ class ClassData {
                     out_begin(format("%s %s {", entityType, entityName));
                 }
             } catch (Exception e) {
-                entityName = environment.getInputFileName();
+                entityName = environment.getInputFile().getFileName();
                 environment.println("// " + e.getMessage() + " while accessing entityName");
                 out_begin(format("%s %s { // source file name", entityType, entityName));
             }

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -40,8 +40,6 @@ import static org.openjdk.asmtools.util.ProductInfo.FULL_VERSION;
  */
 public class Main extends JdecTool {
 
-    private ArrayList<ToolInput> fileList = new ArrayList<>();
-
     public Main(PrintStream toolOutput, String... argv) {
         super(toolOutput);
         parseArgs(argv);

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools.jdec;
 
+import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.common.uEscWriter;
 
 import java.io.*;
@@ -39,7 +40,7 @@ import static org.openjdk.asmtools.util.ProductInfo.FULL_VERSION;
  */
 public class Main extends JdecTool {
 
-    private ArrayList<String> fileList = new ArrayList<>();
+    private ArrayList<ToolInput> fileList = new ArrayList<>();
 
     public Main(PrintStream toolOutput, String... argv) {
         super(toolOutput);
@@ -110,19 +111,21 @@ public class Main extends JdecTool {
                 case "-version":
                     environment.println(FULL_VERSION);
                     break;
+                case "-h", "-help":
+                    usage();
+                    System.exit(OK);
                 default:
                     if (arg.startsWith("-")) {
                         environment.error("err.invalid_option", arg);
                         usage();
                         System.exit(FAILED);
                     } else {
-                        fileList.add(arg);
+                        fileList.add(new ToolInput.FileInput(arg));
                     }
             }
         }
         if (fileList.isEmpty()) {
-            usage();
-            System.exit(FAILED);
+            fileList.add(new ToolInput.StdinInput());
         }
     }
 
@@ -130,7 +133,7 @@ public class Main extends JdecTool {
      * Run the decoder
      */
     public synchronized int decode() {
-        for (String inputFileName : fileList) {
+        for (ToolInput inputFileName : fileList) {
             try {
 //                DataInputStream dataInputStream = getDataInputStream(inpname);
 //                if (dataInputStream == null)

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -22,7 +22,7 @@
  */
 package org.openjdk.asmtools.jdec;
 
-import org.openjdk.asmtools.common.structure.ToolInput;
+import org.openjdk.asmtools.common.ToolInput;
 import org.openjdk.asmtools.common.uEscWriter;
 
 import java.io.*;

--- a/src/org/openjdk/asmtools/jdec/i18n.properties
+++ b/src/org/openjdk/asmtools/jdec/i18n.properties
@@ -20,7 +20,8 @@
 # questions.
 info.usage=\
 Usage: java -jar asmtools.jar jdec [options] FILE.class... > FILE.jcod\n\
-where possible options include:
+if no FILE.class is provided, stdin is used\n\
+possible options include:
 info.opt.g=\
 \     -g       Generate a detailed output format
 info.opt.t=\

--- a/src/org/openjdk/asmtools/jdis/ClassData.java
+++ b/src/org/openjdk/asmtools/jdis/ClassData.java
@@ -120,16 +120,14 @@ public class ClassData extends MemberData<ClassData> {
 
     public void read(File inputFile) throws IOException {
         try (DataInputStream dis = new DataInputStream(new FileInputStream(inputFile))) {
-            read(dis);
+            read(dis, inputFile.toPath());
         }
-        classFile = inputFile.toPath();
     }
 
     public void read(String inputFileName) throws IOException {
         try (DataInputStream dis = new DataInputStream(new FileInputStream(inputFileName))) {
-            read(dis);
+            read(dis, Paths.get(inputFileName));
         }
-        classFile = Paths.get(inputFileName);
     }
 
     /**
@@ -250,7 +248,8 @@ public class ClassData extends MemberData<ClassData> {
     /**
      * Read and resolve the class data
      */
-    private void read(DataInputStream in) throws IOException {
+    public void read(final DataInputStream in, final Path src) throws IOException {
+        classFile = src;
         // Read the header
         try {
             int magic = in.readInt();

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -24,6 +24,7 @@ package org.openjdk.asmtools.jdis;
 
 // import org.openjdk.asmtools.common.Tool;
 
+import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.common.uEscWriter;
 
 import java.io.FileNotFoundException;
@@ -44,7 +45,7 @@ import static org.openjdk.asmtools.util.ProductInfo.FULL_VERSION;
  */
 public class Main extends JdisTool {
 
-    private ArrayList<String> fileList = new ArrayList<>();
+    private ArrayList<ToolInput> fileList = new ArrayList<>();
 
     public Main(PrintStream toolOutput, String... argv) {
         super(toolOutput);
@@ -69,11 +70,11 @@ public class Main extends JdisTool {
 
     // Run disassembler when args already parsed
     public synchronized int disasm() {
-        for (String inputFileName : fileList) {
+        for (ToolInput inputFileName : fileList) {
             try {
-                environment.setInputFile(inputFileName);
+                environment.setInputFile(inputFileName.getFileName());
                 ClassData classData = new ClassData(environment);
-                classData.read(inputFileName);
+                inputFileName.provide(classData);
                 classData.print();
                 environment.getToolOutput().flush();
                 continue;
@@ -142,20 +143,25 @@ public class Main extends JdisTool {
                     break;
                 case "-version":
                     environment.println(FULL_VERSION);
-                    break;
+                    System.exit(OK);
+                case "-h":
+                    usage();
+                    System.exit(OK);
+                case "-help":
+                    usage();
+                    System.exit(OK);
                 default:
                     if (arg.startsWith("-")) {
                         environment.error("err.invalid_option", arg);
                         usage();
                         System.exit(FAILED);
                     } else {
-                        fileList.add(arg);
+                        fileList.add(new ToolInput.FileInput(arg));
                     }
             }
         }
         if (fileList.isEmpty()) {
-            usage();
-            System.exit(FAILED);
+            fileList.add(new ToolInput.StdinInput());
         }
     }
 }

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -27,11 +27,14 @@ package org.openjdk.asmtools.jdis;
 import org.openjdk.asmtools.common.structure.ToolInput;
 import org.openjdk.asmtools.common.uEscWriter;
 
+import java.io.DataInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Optional;
 
 import static org.openjdk.asmtools.common.Environment.FAILED;
 import static org.openjdk.asmtools.common.Environment.OK;
@@ -74,7 +77,9 @@ public class Main extends JdisTool {
             try {
                 environment.setInputFile(inputFileName);
                 ClassData classData = new ClassData(environment);
-                inputFileName.provide(classData);
+                try(DataInputStream dis=inputFileName.getDataInputStream(Optional.of(environment))) {
+                    classData.read(dis, Paths.get(inputFileName.getFileName()));
+                }
                 classData.print();
                 environment.getToolOutput().flush();
                 continue;

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -72,7 +72,7 @@ public class Main extends JdisTool {
     public synchronized int disasm() {
         for (ToolInput inputFileName : fileList) {
             try {
-                environment.setInputFile(inputFileName.getFileName());
+                environment.setInputFile(inputFileName);
                 ClassData classData = new ClassData(environment);
                 inputFileName.provide(classData);
                 classData.print();
@@ -144,10 +144,7 @@ public class Main extends JdisTool {
                 case "-version":
                     environment.println(FULL_VERSION);
                     System.exit(OK);
-                case "-h":
-                    usage();
-                    System.exit(OK);
-                case "-help":
+                case "-h", "-help":
                     usage();
                     System.exit(OK);
                 default:

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -24,7 +24,7 @@ package org.openjdk.asmtools.jdis;
 
 // import org.openjdk.asmtools.common.Tool;
 
-import org.openjdk.asmtools.common.structure.ToolInput;
+import org.openjdk.asmtools.common.ToolInput;
 import org.openjdk.asmtools.common.uEscWriter;
 
 import java.io.DataInputStream;

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -48,8 +48,6 @@ import static org.openjdk.asmtools.util.ProductInfo.FULL_VERSION;
  */
 public class Main extends JdisTool {
 
-    private ArrayList<ToolInput> fileList = new ArrayList<>();
-
     public Main(PrintStream toolOutput, String... argv) {
         super(toolOutput);
         parseArgs(argv);

--- a/src/org/openjdk/asmtools/jdis/i18n.properties
+++ b/src/org/openjdk/asmtools/jdis/i18n.properties
@@ -21,7 +21,8 @@
 
 info.usage=\
 Usage: java -jar asmtools.jar jdis [options] FILE.class... > FILE.jasm\n\
-where possible options include:
+If no FILE.class is provided, stdin is awaited\n\
+possible options include:
 
 info.opt.g=\
 \     -g       Generate a detailed output format

--- a/test/org/openjdk/asmtools/jdec/MainTest.java
+++ b/test/org/openjdk/asmtools/jdec/MainTest.java
@@ -5,7 +5,10 @@ import org.junit.jupiter.api.Test;
 import org.openjdk.asmtools.ThreeStringWriters;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 
 class MainTest {
@@ -14,7 +17,6 @@ class MainTest {
     public void main3StreamsNoSuchFileError() {
         ThreeStringWriters outs = new ThreeStringWriters();
         String nonExisitngFile = "someNonExiostingFile";
-        //for 0 file args, there is hardcoded System.exit
         Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), nonExisitngFile);
         int i = decoder.decode();
         outs.flush();
@@ -35,6 +37,27 @@ class MainTest {
         Assertions.assertFalse(outs.getToolBos().isEmpty());
         Assertions.assertTrue(outs.getErrorBos().isEmpty());
         Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+        Assertions.assertTrue(outs.getToolBos().contains("0xCAFEBABE;"));
+    }
+
+    @Test
+    public void main3StreamsStdinCorrectStream() throws IOException {
+        ThreeStringWriters outs = new ThreeStringWriters();
+        File in =  new File("./target/classes/org/openjdk/asmtools/jdec/Main.class");
+        InputStream is = System.in;
+        try {
+            System.setIn(new FileInputStream(in));
+            Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput());
+            int i = decoder.decode();
+            outs.flush();
+            Assertions.assertEquals(0, i);
+            Assertions.assertFalse(outs.getToolBos().isEmpty());
+            Assertions.assertTrue(outs.getErrorBos().isEmpty());
+            Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+            Assertions.assertTrue(outs.getToolBos().contains("0xCAFEBABE"));
+        }finally {
+            System.setIn(is);
+        }
     }
 
 }

--- a/test/org/openjdk/asmtools/jdis/MainTest.java
+++ b/test/org/openjdk/asmtools/jdis/MainTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.openjdk.asmtools.ThreeStringWriters;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
@@ -15,7 +17,6 @@ class MainTest {
     public void main3StreamsNoSuchFileError() {
         ThreeStringWriters outs = new ThreeStringWriters();
         String nonExisitngFile = "someNonExiostingFile";
-        //for 0 file args, there is hardcoded System.exit
         Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), nonExisitngFile);
         int i = decoder.disasm();
         outs.flush();
@@ -36,6 +37,27 @@ class MainTest {
         Assertions.assertFalse(outs.getToolBos().isEmpty());
         Assertions.assertTrue(outs.getErrorBos().isEmpty());
         Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+        Assertions.assertTrue(outs.getToolBos().contains("invoke"));
+    }
+
+    @Test
+    public void main3StreamsStdinCorrectStream() throws IOException {
+        ThreeStringWriters outs = new ThreeStringWriters();
+        File in =  new File("./target/classes/org/openjdk/asmtools/jdis/Main.class");
+        InputStream is = System.in;
+        try {
+            System.setIn(new FileInputStream(in));
+            Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput());
+            int i = decoder.disasm();
+            outs.flush();
+            Assertions.assertEquals(0, i);
+            Assertions.assertFalse(outs.getToolBos().isEmpty());
+            Assertions.assertTrue(outs.getErrorBos().isEmpty());
+            Assertions.assertTrue(outs.getLoggerBos().isEmpty());
+            Assertions.assertTrue(outs.getToolBos().contains("invoke"));
+        }finally {
+            System.setIn(is);
+        }
     }
 
 


### PR DESCRIPTION
Now Added support for stdin in jdis. Before merging, I would like to add support to all four (not sure with jcdec) tools.
This PR serves for early feedback in approach. Hintsvery  welcomed. 

I personally miss stdin support in this toolchain. Also I think, that for any (test) wrapper, stdin will be much more comfortable then constantly create tmp files

As for the possibel future (test) wrapper, most likely custom stream implementation of ToolInput will arrive sooner or later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Leonid Kuskov](https://openjdk.org/census#lkuskov) (@lkuskov - Committer) ⚠️ Review applies to [3897ac99](https://git.openjdk.org/asmtools/pull/32/files/3897ac999f1709cb6c4a2d01e5080642fc680cbb)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.org/asmtools pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/32.diff">https://git.openjdk.org/asmtools/pull/32.diff</a>

</details>
