### PR TITLE
Unstuck version

### DIFF
--- a/src/org/openjdk/asmtools/Main.java
+++ b/src/org/openjdk/asmtools/Main.java
@@ -34,6 +34,7 @@ public class Main {
 
     public static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Main.class);
     public static final String VERSION_SWITCH="-version";
+    public static final String STDIN_SWITCH="-";
 
     /**
      * Parses the first argument and deligates execution to an appropriate tool

--- a/src/org/openjdk/asmtools/Main.java
+++ b/src/org/openjdk/asmtools/Main.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools;
 
+import org.openjdk.asmtools.common.Environment;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 import org.openjdk.asmtools.util.ProductInfo;
 
@@ -32,6 +33,7 @@ import org.openjdk.asmtools.util.ProductInfo;
 public class Main {
 
     public static final I18NResourceBundle i18n = I18NResourceBundle.getBundleForClass(Main.class);
+    public static final String VERSION_SWITCH="-version";
 
     /**
      * Parses the first argument and deligates execution to an appropriate tool
@@ -44,9 +46,10 @@ public class Main {
         }
         String cmd = args[0];
         if (cmd.equals("-?") || cmd.equals("-h") || cmd.equals("-help")) {
-            usage(null, 0);
-        } else if (cmd.equals("-version")) {
+            usage(null, Environment.OK);
+        } else if (cmd.equals(VERSION_SWITCH)) {
             printVersion();
+            System.exit(Environment.OK);
         } else {
             String[] newArgs = new String[args.length - 1];
             System.arraycopy(args, 1, newArgs, 0, args.length - 1);

--- a/src/org/openjdk/asmtools/common/Tool.java
+++ b/src/org/openjdk/asmtools/common/Tool.java
@@ -85,4 +85,14 @@ public abstract class Tool<T extends Environment<? extends ToolLogger>> {
         }
         return destDir;
     }
+
+    protected void addStdIn() {
+        for (ToolInput toolInput: fileList) {
+            if (toolInput instanceof ToolInput.StdinInput) {
+                //or throw?
+                return;
+            }
+        }
+        fileList.add(new ToolInput.StdinInput());
+    }
 }

--- a/src/org/openjdk/asmtools/common/ToolInput.java
+++ b/src/org/openjdk/asmtools/common/ToolInput.java
@@ -76,10 +76,14 @@ public interface ToolInput {
     public static class ByteInput implements  ToolInput {
 
         //compilers passes input more then one times, so saving it for reuse;
-        private final byte[] bytes;
+        protected byte[] bytes;
 
         public ByteInput(final byte[] bytes) {
             this.bytes = bytes;
+        }
+
+        protected ByteInput() {
+
         }
 
         public ByteInput(final String bytes) {
@@ -97,13 +101,19 @@ public interface ToolInput {
             return getFileName();
         }
 
+        protected void init() {
+
+        }
+
         @Override
         public DataInputStream getDataInputStream(Optional<Environment> logger) throws URISyntaxException, IOException {
+            init();
             return new DataInputStream(new ByteArrayInputStream(bytes));
         }
 
         @Override
         public Collection<String> readAllLines() throws IOException {
+            init();
             ArrayList r = new ArrayList();
             try(BufferedReader br = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(bytes), "utf-8"))){
                 while(true){
@@ -120,8 +130,17 @@ public interface ToolInput {
 
     public static class StreamInput extends ByteInput {
 
+        private final InputStream originalStream;
+
         public StreamInput(InputStream is) {
-            super(drainIs(is));
+            originalStream = is;
+        }
+
+        @Override
+        protected void init() {
+            if (bytes == null){
+                bytes=drainIs(originalStream);
+            }
         }
 
         public static byte[] drainIs(InputStream is) {

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.regex.PatternSyntaxException;
 
 import static org.openjdk.asmtools.common.Environment.FAILED;
@@ -204,6 +203,10 @@ public class Main extends JasmTool {
                             }
                         }
                     }
+                    case org.openjdk.asmtools.Main.STDIN_SWITCH -> {
+                        addStdIn();
+                        break;
+                    }
                     default -> {
                         if (arg.startsWith("-")) {
                             environment.error("err.invalid_option", arg);
@@ -215,8 +218,9 @@ public class Main extends JasmTool {
                     }
                 }
             }
-            if (fileList.size() == 0) {
-                fileList.add(new ToolInput.StdinInput());
+            if (fileList.isEmpty()) {
+                usage();
+                System.exit(FAILED);
             }
         } catch (IllegalArgumentException iae) {
             if (environment.hasMessages()) {

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -145,7 +145,10 @@ public class Main extends JasmTool {
                     case "-strict" -> environment.setStrictWarnings(true);
                     case "-nowarn" -> environment.setIgnoreWarnings(true);
                     case "-nowrite" -> noWriteFlag = true;
-                    case "-version" -> environment.println(FULL_VERSION);
+                    case org.openjdk.asmtools.Main.VERSION_SWITCH -> {
+                        environment.println(FULL_VERSION);
+                        System.exit(OK);
+                    }
                     case "-d" -> destDir = setDestDir(++i, argv);
                     case "-h", "-help" -> {
                         usage();

--- a/src/org/openjdk/asmtools/jasm/i18n.properties
+++ b/src/org/openjdk/asmtools/jasm/i18n.properties
@@ -20,7 +20,7 @@
 # questions.
 info.usage=\
 Usage: java -jar asmtools.jar jasm [options] file.jasm...\n\
-if no file.jasm is provided, stdin is used\n\
+if - is provided, stdin is used\n\
 possible options include:
 info.opt.d=\
 \     -d <directory>        Specify where to place generated class files

--- a/src/org/openjdk/asmtools/jcdec/Main.java
+++ b/src/org/openjdk/asmtools/jcdec/Main.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools.jcdec;
 
+import static org.openjdk.asmtools.common.Environment.OK;
 import static org.openjdk.asmtools.jcoder.JcodTokens.*;
 import org.openjdk.asmtools.common.uEscWriter;
 import org.openjdk.asmtools.util.I18NResourceBundle;
@@ -874,8 +875,9 @@ public class Main {
                 DebugFlag = true;
                 vargs.add(arg);
                 out.println("arg[" + i + "]=" + argv[i] + "/verbose");
-            } else if (arg.equals("-version")) {
+            } else if (arg.equals(org.openjdk.asmtools.Main.VERSION_SWITCH)) {
                 out.println(ProductInfo.FULL_VERSION);
+                System.exit(OK);
             } else if (arg.startsWith("-")) {
 //out.println("arg["+i+"]="+argv[i]+"/invalid flag");
                 error(i18n.getString("jcdec.error.invalid_flag", arg));

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -148,6 +148,10 @@ public class Main extends JcoderTool {
                         usage();
                         System.exit((OK));
                     }
+                    case org.openjdk.asmtools.Main.STDIN_SWITCH -> {
+                        addStdIn();
+                        break;
+                    }
                     default -> {
                         if (arg.startsWith("-")) {
                             environment.error("err.invalid_option", arg);
@@ -159,8 +163,9 @@ public class Main extends JcoderTool {
                     }
                 }
             }
-            if (fileList.size() == 0) {
-                fileList.add(new ToolInput.StdinInput());
+            if (fileList.isEmpty()) {
+                usage();
+                System.exit(FAILED);
             }
         } catch (IllegalArgumentException iae) {
             if (environment.hasMessages()) {

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -140,7 +140,10 @@ public class Main extends JcoderTool {
                     }
                     case "-nowrite" -> noWriteFlag = true;
                     case "-ignore" -> ignoreFlag = true;
-                    case "-version" -> environment.println(FULL_VERSION);
+                    case org.openjdk.asmtools.Main.VERSION_SWITCH -> {
+                        environment.println(FULL_VERSION);
+                        System.exit(OK);
+                    }
                     case "-h", "-help" -> {
                         usage();
                         System.exit((OK));

--- a/src/org/openjdk/asmtools/jcoder/i18n.properties
+++ b/src/org/openjdk/asmtools/jcoder/i18n.properties
@@ -20,7 +20,7 @@
 # questions.
 info.usage=\
 Usage: java -jar asmtools.jar jcoder [options] file.jcod...\n\
-if no file.jcod is provided, stdin is used\n\
+if - is provided, stdin is used\n\
 possible options include:
 info.opt.nowrite=\
 \     -nowrite        Do not write generated class files

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -26,7 +26,6 @@ import org.openjdk.asmtools.common.ToolInput;
 import org.openjdk.asmtools.common.uEscWriter;
 
 import java.io.*;
-import java.util.ArrayList;
 
 import static org.openjdk.asmtools.common.Environment.FAILED;
 import static org.openjdk.asmtools.common.Environment.OK;
@@ -112,6 +111,9 @@ public class Main extends JdecTool {
                 case "-h", "-help":
                     usage();
                     System.exit(OK);
+                case org.openjdk.asmtools.Main.STDIN_SWITCH:
+                    addStdIn();
+                    break;
                 default:
                     if (arg.startsWith("-")) {
                         environment.error("err.invalid_option", arg);
@@ -123,7 +125,8 @@ public class Main extends JdecTool {
             }
         }
         if (fileList.isEmpty()) {
-            fileList.add(new ToolInput.StdinInput());
+            usage();
+            System.exit(FAILED);
         }
     }
 

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -106,9 +106,9 @@ public class Main extends JdecTool {
                     environment.setVerboseFlag(true);
                     environment.setTraceFlag(true);
                     break;
-                case "-version":
+                case org.openjdk.asmtools.Main.VERSION_SWITCH:
                     environment.println(FULL_VERSION);
-                    break;
+                    System.exit(OK);
                 case "-h", "-help":
                     usage();
                     System.exit(OK);

--- a/src/org/openjdk/asmtools/jdec/i18n.properties
+++ b/src/org/openjdk/asmtools/jdec/i18n.properties
@@ -20,7 +20,7 @@
 # questions.
 info.usage=\
 Usage: java -jar asmtools.jar jdec [options] FILE.class... > FILE.jcod\n\
-if no FILE.class is provided, stdin is used\n\
+if - is provided, stdin is used\n\
 possible options include:
 info.opt.g=\
 \     -g       Generate a detailed output format

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -144,7 +144,7 @@ public class Main extends JdisTool {
                 case "-hx":
                     Options.set(Options.PR.HEX);
                     break;
-                case "-version":
+                case org.openjdk.asmtools.Main.VERSION_SWITCH:
                     environment.println(FULL_VERSION);
                     System.exit(OK);
                 case "-h", "-help":

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -147,6 +147,9 @@ public class Main extends JdisTool {
                 case org.openjdk.asmtools.Main.VERSION_SWITCH:
                     environment.println(FULL_VERSION);
                     System.exit(OK);
+                case org.openjdk.asmtools.Main.STDIN_SWITCH:
+                    addStdIn();
+                    break;
                 case "-h", "-help":
                     usage();
                     System.exit(OK);
@@ -161,7 +164,8 @@ public class Main extends JdisTool {
             }
         }
         if (fileList.isEmpty()) {
-            fileList.add(new ToolInput.StdinInput());
+            usage();
+            System.exit(FAILED);
         }
     }
 }

--- a/src/org/openjdk/asmtools/jdis/i18n.properties
+++ b/src/org/openjdk/asmtools/jdis/i18n.properties
@@ -21,7 +21,7 @@
 
 info.usage=\
 Usage: java -jar asmtools.jar jdis [options] FILE.class... > FILE.jasm\n\
-If no FILE.class is provided, stdin is awaited\n\
+If - is provided, stdin is used\n\
 possible options include:
 
 info.opt.g=\

--- a/test/org/openjdk/asmtools/ClassPathClassWork.java
+++ b/test/org/openjdk/asmtools/ClassPathClassWork.java
@@ -1,0 +1,23 @@
+package org.openjdk.asmtools;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.io.File;
+import java.util.regex.Pattern;
+
+public class ClassPathClassWork {
+
+    protected static Class clazz;
+    protected static String classFile;
+    protected static Pattern className;
+    protected static Pattern packageName;
+
+    public static void initClassData(Class testsClass) {
+        clazz = testsClass;
+        classFile = "./target/classes/" + clazz.getName().replace('.', '/') + ".class";
+        Assertions.assertTrue(new File(classFile).exists());
+        className  = Pattern.compile("public .*class .*" + clazz.getSimpleName() + " extends .*");
+        packageName = Pattern.compile("package "+clazz.getPackageName() + ";");
+    }
+
+}

--- a/test/org/openjdk/asmtools/jdec/MainTest.java
+++ b/test/org/openjdk/asmtools/jdec/MainTest.java
@@ -1,17 +1,23 @@
 package org.openjdk.asmtools.jdec;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.openjdk.asmtools.ClassPathClassWork;
 import org.openjdk.asmtools.ThreeStringWriters;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
+import java.util.regex.Pattern;
 
-class MainTest {
+class MainTest extends ClassPathClassWork {
+
+    @BeforeAll
+    public static void prepareClass() {
+        initClassData(org.openjdk.asmtools.jdec.Main.class);
+    }
 
     @Test
     public void main3StreamsNoSuchFileError() {
@@ -30,7 +36,7 @@ class MainTest {
     @Test
     public void main3StreamsFileInCorrectStream() throws IOException {
         ThreeStringWriters outs = new ThreeStringWriters();
-        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), "./target/classes/org/openjdk/asmtools/jdec/Main.class");
+        Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), classFile);
         int i = decoder.decode();
         outs.flush();
         Assertions.assertEquals(0, i);
@@ -43,11 +49,11 @@ class MainTest {
     @Test
     public void main3StreamsStdinCorrectStream() throws IOException {
         ThreeStringWriters outs = new ThreeStringWriters();
-        File in =  new File("./target/classes/org/openjdk/asmtools/jdec/Main.class");
+        File in =  new File(classFile);
         InputStream is = System.in;
         try {
             System.setIn(new FileInputStream(in));
-            Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput());
+            Main decoder = new Main(outs.getToolOutput(), outs.getErrorOutput(), outs.getLoggerOutput(), org.openjdk.asmtools.Main.STDIN_SWITCH);
             int i = decoder.decode();
             outs.flush();
             Assertions.assertEquals(0, i);


### PR DESCRIPTION
Hello! This pr is solving - and is not - the hanged waiting for stdin for no file argument.
1) it properly exits after version is printed, thus is unaffected by any file arguments (and streams) which may change alter
2) it changes the Stream (and extending) input implemetation to lazily drain the stream once needed, not durign construction. TBH, I'm not sure with this change, but I was generally very unhappy  by draining the stream in cosntructor at all. This alone, would not solve the -version problem, because the StreamInput is added always, and thus is always processed, thus stdin is read no meter if it is lazy or in constructor.

This intentionally do not add the empty "-" switch. That may come later as needed.

Hints welcomed!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/asmtools pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/36.diff">https://git.openjdk.org/asmtools/pull/36.diff</a>

</details>
