### PR TITLE
WIP repalce stdout by configurable object

### DIFF
--- a/src/org/openjdk/asmtools/common/Environment.java
+++ b/src/org/openjdk/asmtools/common/Environment.java
@@ -142,10 +142,10 @@ public abstract class Environment<T extends ToolLogger> implements ILogger {
      */
     public abstract static class Builder<E extends Environment, T extends ToolLogger> {
         T toolLogger;
-        public PrintWriter toolOutput;
+        public ToolOutput toolOutput;
         protected String programName;
 
-        public Builder(String programName, PrintWriter toolOutput, T toolLogger) {
+        public Builder(String programName, ToolOutput toolOutput, T toolLogger) {
             this.programName = programName;
             this.toolOutput = toolOutput;
             this.toolLogger = toolLogger;

--- a/src/org/openjdk/asmtools/common/Tool.java
+++ b/src/org/openjdk/asmtools/common/Tool.java
@@ -34,11 +34,11 @@ public abstract class Tool<T extends Environment<? extends ToolLogger>> {
     protected final ArrayList<ToolInput> fileList = new ArrayList<>();
     protected T environment;
 
-    protected Tool(PrintWriter toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
+    protected Tool(ToolOutput toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
         this.environment = getEnvironment(toolOutput, errorLogger, outputLogger);
     }
 
-    protected Tool(PrintWriter errorLogger, PrintWriter outputLogger) {
+    protected Tool(PrintWriter errorLogger, ToolOutput outputLogger) {
         this.environment = getEnvironment(errorLogger, outputLogger);
     }
 
@@ -57,11 +57,11 @@ public abstract class Tool<T extends Environment<? extends ToolLogger>> {
     }
 
     // Build environment
-    public T getEnvironment(PrintWriter toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
+    public T getEnvironment(ToolOutput toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
         throw new NotImplementedException();
     }
 
-    public T getEnvironment(PrintWriter errorLogger, PrintWriter outputLogger) {
+    public T getEnvironment(PrintWriter errorLogger, ToolOutput outputLogger) {
         throw new NotImplementedException();
     }
 

--- a/src/org/openjdk/asmtools/common/ToolOutput.java
+++ b/src/org/openjdk/asmtools/common/ToolOutput.java
@@ -1,0 +1,164 @@
+package org.openjdk.asmtools.common;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+
+
+public interface ToolOutput {
+
+    String getCurrentClassName();
+
+    void startClass(String fqn) throws IOException;
+
+    void finishClass(String fqn) throws IOException;
+
+    void addClassOutputListener(ClassProgressListener l);
+
+    void removeClassOutputListener(ClassProgressListener l);
+
+    void println(String line);
+    void print(String line);
+    void print(char line);
+
+    public interface ClassProgressListener {
+
+        public void classStarted(String fqn);
+
+        public void classEnded(String fqn);
+
+    }
+
+
+    public static abstract class ObservableToolOutput implements ToolOutput {
+
+        protected ArrayList<ClassProgressListener> classProgressListeners = new ArrayList<>();
+        protected String currentFqn = null;
+
+        @Override
+        public String getCurrentClassName() {
+            return currentFqn;
+        }
+
+        @Override
+        public void addClassOutputListener(ClassProgressListener l) {
+            classProgressListeners.add(l);
+        }
+
+        @Override
+        public void removeClassOutputListener(ClassProgressListener l) {
+            if (!classProgressListeners.remove(l)) {
+                throw new RuntimeException("ClassProgressListener " + l + " not registered");
+            }
+        }
+
+        @Override
+        public void startClass(String fqn) throws IOException {
+            currentFqn = fqn;
+            for (ClassProgressListener classProgressListener : classProgressListeners) {
+                classProgressListener.classEnded(fqn);
+            }
+        }
+
+        @Override
+        public void finishClass(String fqn) throws IOException {
+            try {
+                for (ClassProgressListener classProgressListener : classProgressListeners) {
+                    classProgressListener.classEnded(fqn);
+                }
+            } finally {
+                currentFqn = null;
+            }
+        }
+    }
+
+
+    public static class DirOutput extends ObservableToolOutput {
+
+        private final String dir;
+        private final ClassProgressListener classProgressListener;
+
+        public DirOutput(String dir) {
+            this.dir = dir;
+            classProgressListener = new ClassProgressListener() {
+
+                @Override
+                public void classStarted(String fqn) {
+                    //mkdir
+                    //fileopen
+
+                }
+
+                @Override
+                public void classEnded(String fqn) {
+                    //fileclose
+                }
+            };
+        }
+
+
+        @Override
+        public String toString() {
+            return super.toString() + " to " + dir;
+        }
+
+        @Override
+        public void println(String line) {
+            throw new RuntimeException("Not yet implemented");
+        }
+        @Override
+        public void print(String line) {
+            throw new RuntimeException("Not yet implemented");
+        }
+        @Override
+        public void print(char line) {
+            throw new RuntimeException("Not yet implemented");
+        }
+    }
+
+    public static class OutputStreamOutput extends ObservableToolOutput {
+
+        private PrintStream os;
+
+        public OutputStreamOutput(PrintStream os) {
+            //although it is usually System.out, it is set from Environment, or custom
+            this.os = os;
+        }
+
+        /**
+         * One can chane the stream as action to new class
+         *
+         * @param os
+         */
+        public void setOutputStream(PrintStream os) {
+            this.os = os;
+        }
+
+        @Override
+        public void println(String line) {
+            throw new RuntimeException("Not yet implemented");
+        }
+        @Override
+        public void print(String line) {
+            throw new RuntimeException("Not yet implemented");
+        }
+        @Override
+        public void print(char line) {
+            throw new RuntimeException("Not yet implemented");
+        }
+
+        @Override
+        public void finishClass(String fqn) throws IOException {
+            try {
+                super.finishClass(fqn);
+            } finally {
+                os.flush();
+            }
+        }
+
+
+    }
+
+}
+

--- a/src/org/openjdk/asmtools/jcoder/JcoderEnvironment.java
+++ b/src/org/openjdk/asmtools/jcoder/JcoderEnvironment.java
@@ -26,6 +26,7 @@ import org.openjdk.asmtools.common.CompilerLogger;
 import org.openjdk.asmtools.common.EMessageKind;
 import org.openjdk.asmtools.common.Environment;
 import org.openjdk.asmtools.common.ToolInput;
+import org.openjdk.asmtools.common.ToolOutput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.*;
@@ -109,7 +110,7 @@ public class JcoderEnvironment extends Environment<CompilerLogger> {
 
     static class JcoderBuilder extends Builder<JcoderEnvironment, CompilerLogger> {
 
-        public JcoderBuilder(PrintWriter errorLogger, PrintWriter outputLogger) {
+        public JcoderBuilder(PrintWriter errorLogger, ToolOutput outputLogger) {
             super("jcoder", new CompilerLogger(errorLogger, outputLogger));
         }
 

--- a/src/org/openjdk/asmtools/jcoder/JcoderTool.java
+++ b/src/org/openjdk/asmtools/jcoder/JcoderTool.java
@@ -23,6 +23,7 @@
 package org.openjdk.asmtools.jcoder;
 
 import org.openjdk.asmtools.common.Tool;
+import org.openjdk.asmtools.common.ToolOutput;
 
 import java.io.PrintWriter;
 
@@ -30,15 +31,15 @@ public abstract class JcoderTool extends Tool<JcoderEnvironment> {
 
 
     protected JcoderTool() {
-        super(new PrintWriter(System.err, true), new PrintWriter(System.out, true));
+        super(new PrintWriter(System.err, true), new ToolOutput.OutputStreamOutput(System.out));
     }
 
-    protected JcoderTool(PrintWriter errorLogger, PrintWriter outputLogger) {
+    protected JcoderTool(PrintWriter errorLogger, ToolOutput outputLogger) {
         super(errorLogger, outputLogger);
     }
 
     @Override
-    public JcoderEnvironment getEnvironment(PrintWriter errorLogger, PrintWriter outputLogger) {
+    public JcoderEnvironment getEnvironment(PrintWriter errorLogger, ToolOutput outputLogger) {
         JcoderEnvironment.JcoderBuilder builder = new JcoderEnvironment.JcoderBuilder(errorLogger, outputLogger);
         return builder.build();
     }

--- a/src/org/openjdk/asmtools/jdec/JdecEnvironment.java
+++ b/src/org/openjdk/asmtools/jdec/JdecEnvironment.java
@@ -24,6 +24,7 @@ package org.openjdk.asmtools.jdec;
 
 import org.openjdk.asmtools.common.DecompilerLogger;
 import org.openjdk.asmtools.common.Environment;
+import org.openjdk.asmtools.common.ToolOutput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.PrintWriter;
@@ -34,8 +35,8 @@ public class JdecEnvironment extends Environment<DecompilerLogger> {
 
     protected boolean printDetailsFlag;
 
-    // Output stream
-    private final PrintWriter toolOutput;
+    // Output stream or files or custom Strings
+    private final ToolOutput toolOutput;
 
     private JdecEnvironment(Builder<JdecEnvironment, DecompilerLogger> builder, I18NResourceBundle i18n) {
         super(builder, i18n);
@@ -47,7 +48,7 @@ public class JdecEnvironment extends Environment<DecompilerLogger> {
         getLogger().printErrorLn(format, args);
     }
 
-    public PrintWriter getToolOutput() {
+    public ToolOutput getToolOutput() {
         return toolOutput;
     }
 
@@ -63,7 +64,7 @@ public class JdecEnvironment extends Environment<DecompilerLogger> {
 
     @Override
     public void println() {
-        getToolOutput().println();
+        getToolOutput().println("");
     }
 
     @Override
@@ -79,7 +80,7 @@ public class JdecEnvironment extends Environment<DecompilerLogger> {
 
     static class JDecBuilder extends Builder<JdecEnvironment, DecompilerLogger> {
 
-        public JDecBuilder(PrintWriter toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
+        public JDecBuilder(ToolOutput toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
             super("jdec", toolOutput, new DecompilerLogger(errorLogger, outputLogger));
         }
 

--- a/src/org/openjdk/asmtools/jdec/JdecTool.java
+++ b/src/org/openjdk/asmtools/jdec/JdecTool.java
@@ -23,6 +23,7 @@
 package org.openjdk.asmtools.jdec;
 
 import org.openjdk.asmtools.common.Tool;
+import org.openjdk.asmtools.common.ToolOutput;
 import org.openjdk.asmtools.common.uEscWriter;
 
 import java.io.PrintStream;
@@ -43,7 +44,7 @@ public abstract class JdecTool extends Tool<JdecEnvironment> {
     }
 
     @Override
-    public JdecEnvironment getEnvironment(PrintWriter toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
+    public JdecEnvironment getEnvironment(ToolOutput toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
         JdecEnvironment.JDecBuilder builder = new JdecEnvironment.JDecBuilder(toolOutput, errorLogger, outputLogger);
         return builder.build();
     }

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -144,7 +144,7 @@ public class Main extends JdecTool {
                 environment.setInputFile(inputFileName);
                 ClassData classData = new ClassData(environment);
                 classData.decodeClass();
-                environment.getToolOutput().flush();
+                environment.getToolOutput().finishClass(inputFileName.getFileName()/*TODO replace by proper pkg.name?*/);
                 continue;
             } catch (FileNotFoundException fnf) {
                 environment.printException(fnf);

--- a/src/org/openjdk/asmtools/jdis/JdisEnvironment.java
+++ b/src/org/openjdk/asmtools/jdis/JdisEnvironment.java
@@ -26,18 +26,16 @@ import org.openjdk.asmtools.common.DecompilerLogger;
 import org.openjdk.asmtools.common.EMessageKind;
 import org.openjdk.asmtools.common.Environment;
 import org.openjdk.asmtools.common.ToolLogger;
+import org.openjdk.asmtools.common.ToolOutput;
 import org.openjdk.asmtools.util.I18NResourceBundle;
 
 import java.io.PrintWriter;
 
 public class JdisEnvironment extends Environment<DecompilerLogger> {
 
-    // Output stream
-    private final PrintWriter toolOutput;
 
     private JdisEnvironment(Builder<JdisEnvironment, DecompilerLogger> builder, I18NResourceBundle i18n) {
         super(builder, i18n);
-        this.toolOutput = builder.toolOutput;
     }
 
     @Override
@@ -51,13 +49,10 @@ public class JdisEnvironment extends Environment<DecompilerLogger> {
                 new ToolLogger.Message(EMessageKind.ERROR, exception.getMessage())));
     }
 
-    public PrintWriter getToolOutput() {
-        return toolOutput;
-    }
 
     static class JDecBuilder extends Environment.Builder<JdisEnvironment, DecompilerLogger> {
 
-        public JDecBuilder(PrintWriter toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
+        public JDecBuilder(ToolOutput toolOutput, PrintWriter errorLogger, PrintWriter outputLogger) {
             super("jdis", toolOutput, new DecompilerLogger(errorLogger, outputLogger));
         }
 


### PR DESCRIPTION
Hello!

This is initial draft of stdout/-d unification, which will allow to use asmtools as universal library, where user will be able to set up his custom ToolInput, ToolOutput and ToolLog implementations

To do that, I should unify stdout and err of the tools. 
Disassembelrs are now logging to stderr and can print to stdout.
Assemblers are now logging to stderr and stdout and stdout only to -d dir

Main question before continuing - why are Assemblers  using both streams for logging? Can I unify them, so they log only to stderr?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/asmtools pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/38.diff">https://git.openjdk.org/asmtools/pull/38.diff</a>

</details>
