### PR TITLE
Naive fix for enforced dot.suffix

### DIFF
--- a/src/org/openjdk/asmtools/common/ToolInput.java
+++ b/src/org/openjdk/asmtools/common/ToolInput.java
@@ -154,7 +154,7 @@ public interface ToolInput {
         @Override
         public String getFileName() {
             //get parent is used
-            return "stdin/in";
+            return "stdin/stdin";
         }
     }
 }

--- a/src/org/openjdk/asmtools/jasm/Parser.java
+++ b/src/org/openjdk/asmtools/jasm/Parser.java
@@ -1974,7 +1974,7 @@ class Parser extends ParseBase {
             classData.relinkBootstrapMethods();
             // Fix Source file
             String sourceFileName = environment.getSimpleInputFileName();
-            String sourceName = sourceFileName.substring(0, sourceFileName.indexOf('.'));
+            String sourceName = sourceFileName.contains(".") ? sourceFileName.substring(0, sourceFileName.indexOf('.')) : sourceFileName;
             classData.sourceFileNameAttr = new SourceFileAttr(this.classData.pool, sourceFileName).
                     updateIfFound( this.classData.pool,
                             name -> name.startsWith(sourceName) &&


### PR DESCRIPTION
See initial story at: https://github.com/openjdk/asmtools/pull/37

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.org/asmtools pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/42.diff">https://git.openjdk.org/asmtools/pull/42.diff</a>

</details>
