### PR TITLE
Added github actions

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -1,0 +1,49 @@
+name: Java CI
+
+on:
+  push:
+    branches:
+      - master
+      - at8
+  pull_request:
+    branches:
+      - master
+      - at8
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java-version: [ 17 ]
+      fail-fast: false
+
+    name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven
+    steps:
+      - name: Checkout asmtools repo
+        uses: actions/checkout@v2
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java-version }}
+          distribution: 'adopt'
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.4
+        with:
+          maven-version: 3.8.4
+
+      - name: Build asmtools with Maven
+        run: |
+            set -x
+            pwd
+            ls
+            cd maven ;
+            bash mvngen.sh  ;
+            mvn "--batch-mode" "--update-snapshots" "clean" "install"
+            mvn "--batch-mode" "--update-snapshots" "test"
+
+


### PR DESCRIPTION
Just for record for "act" for local testing. To run with podman based distros, several steps are ncessary. See https://github.com/nektos/act/issues/303 ; especially
 * https://github.com/nektos/act/issues/303#issuecomment-937698375
 *  and https://github.com/nektos/act/issues/303#issuecomment-962403508
    *   the bind and socket
eg:
 systemctl enable --now --user podman.socket
 systemctl start --user podman.socket
 export DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock
 ../act/bin/act   --bind --container-daemon-socket $XDG_RUNTIME_DIR/podman/podman.sock

 To rerun the build on clean env, you have to stop and start the podman socket again

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.org/asmtools pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/45.diff">https://git.openjdk.org/asmtools/pull/45.diff</a>

</details>
