### PR TITLE
[jasm] IOOB exception when adding parameter names to static methods

### DIFF
--- a/src/org/openjdk/asmtools/jasm/Parser.java
+++ b/src/org/openjdk/asmtools/jasm/Parser.java
@@ -883,6 +883,7 @@ class Parser extends ParseBase {
         scanner.expect(Token.COLON);
         ConstCell typeCell = parseName();
         int paramcnt = countParams(typeCell);
+        int decriptorParams = paramcnt;
         if ((!Modifiers.isStatic(mod)) && !is_clinit) {
             paramcnt++;
         }
@@ -938,7 +939,7 @@ class Parser extends ParseBase {
             max_locals = parseUInt(2);
         }
         if (scanner.token == Token.INTVAL) {
-            annotParser.parseParamAnnots(paramcnt, curMethod);
+            annotParser.parseParamAnnots(decriptorParams, curMethod);
         }
 
         if (scanner.token == SEMICOLON) {

--- a/src/org/openjdk/asmtools/jasm/ParserAnnotation.java
+++ b/src/org/openjdk/asmtools/jasm/ParserAnnotation.java
@@ -294,11 +294,8 @@ public class ParserAnnotation extends ParseBase {
      * @throws org.openjdk.asmtools.jasm.Scanner.SyntaxError
      * @throws IOException
      */
-    protected void parseParamAnnots(int _totalParams, MethodData curMethod) throws Scanner.SyntaxError, IOException {
-        debugScan(" - - - > [ParserAnnotation.parseParamAnnots]: Begin, totalParams =  " + _totalParams + " ");
-        // The _method thinks there are N+1 params in the signature
-        // (N = total params in the call list) + 1 (return value)
-        int totalParams = _totalParams - 1;
+    protected void parseParamAnnots(int totalParams, MethodData curMethod) throws Scanner.SyntaxError, IOException {
+        debugScan(" - - - > [ParserAnnotation.parseParamAnnots]: Begin, totalParams =  " + totalParams + " ");
         TreeMap<Integer, ArrayList<AnnotationData>> pAnnots = new TreeMap<>();
 
         while (scanner.token == Token.INTVAL) {


### PR DESCRIPTION
The last parameter index to a static method would be considered out of bounds due to a bug in the parameter count computation in `ParserAnnotation.parseParamAnnots(…)`, which was only valid for instance methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/asmtools pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/46.diff">https://git.openjdk.org/asmtools/pull/46.diff</a>

</details>
