### PR TITLE
7902888: Excess entries in BootstrapMethods with the same bsm, bsmKind, bsmArgs

### DIFF
--- a/src/org/openjdk/asmtools/Main.java
+++ b/src/org/openjdk/asmtools/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ public class Main {
     public static final String DUAL_LOG_SWITCH ="-dls";
 
     /**
-     * Parses the first argument and deligates execution to an appropriate tool
+     * Parses the first argument and delegates execution to an appropriate tool
      *
      * @param args - command line arguments
      */

--- a/src/org/openjdk/asmtools/jasm/BootstrapMethodData.java
+++ b/src/org/openjdk/asmtools/jasm/BootstrapMethodData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package org.openjdk.asmtools.jasm;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 class BootstrapMethodData extends Indexer implements DataWriter {
 
@@ -37,33 +38,32 @@ class BootstrapMethodData extends Indexer implements DataWriter {
         this.arguments = arguments;
     }
 
-    // placeholder - bootstrap_method_attr_index
+    // methodAttrIndex - bootstrap_method_attr_index
     // The value of the bootstrap_method_attr_index item must be a valid index into the bootstrap_methods array
     // of the bootstrap method table of this class file (§4.7.23).
-    protected BootstrapMethodData clone(int placeholder) {
-        BootstrapMethodData instance = new BootstrapMethodData(this.bootstrapMethodHandle, arguments);
-        instance.cpIndex = placeholder;
-        return instance;
-    }
-
-    // placeholder - bootstrap_method_attr_index
-    // The value of the bootstrap_method_attr_index item must be a valid index into the bootstrap_methods array
-    // of the bootstrap method table of this class file (§4.7.23).
-    public BootstrapMethodData(int placeholder) {
+    public BootstrapMethodData(int methodAttrIndex) {
         super();
         this.bootstrapMethodHandle = null;
         this.arguments = null;
-        this.cpIndex = placeholder;
+        super.cpIndex = methodAttrIndex;
     }
 
     public int getLength() {
         return 4 + arguments.size() * 2;
     }
 
-    public boolean isPlaceholder() {
+    public boolean hasMethodAttrIndex() {
         return super.isSet();
     }
 
+    public void setMethodAttrIndex(int methodAttrIndex) {
+        super.cpIndex = methodAttrIndex;
+    }
+
+    public int getMethodAttrIndex() {
+        return super.cpIndex;
+
+    }
     public void write(CheckedDataOutputStream out) throws IOException {
         out.writeShort(bootstrapMethodHandle.cpIndex);
         out.writeShort(arguments.size());
@@ -74,13 +74,21 @@ class BootstrapMethodData extends Indexer implements DataWriter {
     }
 
     @Override
+    public String toString() {
+        return String.format("{MethodHandle:%s Arguments:%s}",
+                bootstrapMethodHandle == null || bootstrapMethodHandle.cpIndex == NotSet ? " n/a" : " #" + bootstrapMethodHandle.cpIndex,
+                arguments == null || arguments.isEmpty() ? "{}" :
+                        "{ " + arguments.stream().map(a -> String.format("#%d", a.cpIndex)).collect(Collectors.joining(", ")) + " }");
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof BootstrapMethodData)) return false;
         BootstrapMethodData that = (BootstrapMethodData) o;
         if (!Objects.equals(bootstrapMethodHandle, that.bootstrapMethodHandle))
             return false;
-        return Objects.equals(arguments, that.arguments);
+        return this.cpIndex == that.cpIndex & Objects.equals(arguments, that.arguments);
     }
 
     @Override

--- a/src/org/openjdk/asmtools/jasm/ConstValue.java
+++ b/src/org/openjdk/asmtools/jasm/ConstValue.java
@@ -44,6 +44,11 @@ public abstract class ConstValue<T> {
 
     public boolean isSet() { return value != null; }
 
+    public ConstValue<T> setValue(T value) {
+        this.value = value;
+        return this;
+    }
+
     @Override
     public int hashCode() {
         int result = value != null ? value.hashCode() : 0;

--- a/src/org/openjdk/asmtools/jasm/DataVectorAttr.java
+++ b/src/org/openjdk/asmtools/jasm/DataVectorAttr.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
  * InnerClasses, BootstrapMethods, LineNumberTable, Runtime(In)Visible(Type|Parameter)Annotations,
  * LocalVariableTable, StackMapTable
  */
-class DataVectorAttr<T extends DataWriter> extends AttrData implements Iterable<T> {
+class DataVectorAttr<T extends DataWriter> extends AttrData implements Collection<T> {
 
     private ArrayList<T> elements;
     private boolean     byteIndex;
@@ -72,9 +72,39 @@ class DataVectorAttr<T extends DataWriter> extends AttrData implements Iterable<
         return elements.get(index);
     }
 
-    public void add(T element) {
-        if (element != null)
-            elements.add(element);
+    @Override
+    public boolean add(T element) {
+        return elements.add(element);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return elements.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return elements.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        return elements.addAll(c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return elements.removeAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return elements.retainAll(c);
+    }
+
+    @Override
+    public void clear() {
+        elements.clear();
     }
 
     public DataVectorAttr<T> addAll(Stream<T> s) {
@@ -82,11 +112,21 @@ class DataVectorAttr<T extends DataWriter> extends AttrData implements Iterable<
         return this;
     }
 
-    public void put(int i, T element) {
-        elements.set(i, element);
+    public T set(int i, T element) {
+        return elements.set(i, element);
     }
 
     public int size() { return elements.size(); }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return false;
+    }
 
     public void replaceAll(Collection<T> collection) {
         elements.clear();
@@ -101,6 +141,18 @@ class DataVectorAttr<T extends DataWriter> extends AttrData implements Iterable<
     public Iterator<T> iterator() {
         return elements.iterator();
     }
+
+    @Override
+    public Object[] toArray() {
+        return elements.toArray();
+    }
+
+    @Override
+    public <V> V[] toArray(V[] a) {
+        return elements.toArray(a);
+    }
+
+    public Stream<T> stream() { return elements.stream(); };
 
     @Override
     public int attrLength() {
@@ -123,5 +175,4 @@ class DataVectorAttr<T extends DataWriter> extends AttrData implements Iterable<
             elem.write(out);
         }
     }
-
 }

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -27,6 +27,8 @@ import org.openjdk.asmtools.common.structure.CFVersion;
 import org.openjdk.asmtools.common.ToolInput;
 
 import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.regex.PatternSyntaxException;
@@ -86,10 +88,38 @@ public class Main extends JasmTool {
         parseArgs(new String[0]);
     }
 
+    /**
+     * Deprecated method to support external tools having it
+     *
+     * @param ref      A stream to which to write reference output
+     * @param toolName the tool's name (ignored)
+     */
+    @Deprecated
+    public Main(PrintWriter ref, String toolName) {
+        super(new ToolOutput.PrintWriterOutput(ref));
+    }
+
+    /**
+     * Deprecated method to support external tools having it
+     *
+     * @param out      A stream to which to write reference output
+     * @param toolName the tool's name (ignored)
+     */
+    @Deprecated
+    public Main(PrintStream out, String toolName) {
+        this(new PrintWriter(out), toolName);
+    }
+
     // jasm entry point
     public static void main(String... argv) {
         Main compiler = new Main(new ToolOutput.EscapedPrintStreamOutput(System.out), new ToolOutput.SingleDualOutputStreamOutput(), argv);
         System.exit(compiler.compile());
+    }
+
+    // Run jasm compiler with args
+    public synchronized boolean compile(String... argv) {
+        parseArgs(argv);
+        return this.compile() == OK;
     }
 
     // Run jasm compiler when args already parsed

--- a/src/org/openjdk/asmtools/jasm/MethodData.java
+++ b/src/org/openjdk/asmtools/jasm/MethodData.java
@@ -160,7 +160,7 @@ class MethodData extends MemberData<JasmEnvironment> {
                 methodParameters.add(new MethodParameterData(0, null));
             }
         }
-        methodParameters.put(paramNum, new MethodParameterData(access, name));
+        methodParameters.set(paramNum, new MethodParameterData(access, name));
     }
 
     public CodeAttr startCode(int paramCount, Indexer max_stack, Indexer max_locals) {
@@ -208,4 +208,3 @@ class MethodData extends MemberData<JasmEnvironment> {
         getAttrVector().write(out);
     }
 } // end MethodData
-

--- a/src/org/openjdk/asmtools/jasm/Parser.java
+++ b/src/org/openjdk/asmtools/jasm/Parser.java
@@ -557,7 +557,7 @@ class Parser extends ParseBase {
     /**
      * Parse constant declaration
      */
-    private void parseConstDef() throws IOException {
+    private void parseConstDef() {
         for (; ; ) {
             if (scanner.token == Token.CPINDEX) {
                 int cpx = scanner.intValue;

--- a/src/org/openjdk/asmtools/jasm/i18n.properties
+++ b/src/org/openjdk/asmtools/jasm/i18n.properties
@@ -171,6 +171,9 @@ err.itemtype.expected=StackMap item type expected instead of {0}
 err.version.expected=class file version expected
 err.invalid.innerclass=Invalid declaration of Inner Class
 err.invalid.bootstrapmethod=Invalid declaration of BootstrapMethod Entry
+warn.bootstrapmethod.attr.bad=Bad bootstrap method attribute index {0}
+warn.bootstrapmethod.attr.expected=Invoke dynamic \"{0}\" has undefined method attribute index
+
 err.invalid.paramnum=Invalid Parameter Number: {0}
 err.duplicate.paramnum=Duplicate Parameter Number: {0}
 err.paramname.constnum.invaltype=ParameterName CPX at {0} is not a ConstantString

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -26,6 +26,8 @@ import org.openjdk.asmtools.common.ToolInput;
 import org.openjdk.asmtools.common.ToolOutput;
 
 import java.io.IOException;
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.regex.PatternSyntaxException;
@@ -72,6 +74,28 @@ public class Main extends JcoderTool {
         parseArgs(new String[0]);
     }
 
+    /**
+     * Deprecated method to support external tools having it
+     *
+     * @param ref      A stream to which to write reference output
+     * @param toolName the tool's name (ignored)
+     */
+    @Deprecated
+    public Main(PrintWriter ref, String toolName) {
+        super(new ToolOutput.PrintWriterOutput(ref));
+    }
+
+    /**
+     * Deprecated method to support external tools having it
+     *
+     * @param out      A stream to which to write reference output
+     * @param toolName the tool's name (ignored)
+     */
+    @Deprecated
+    public Main(PrintStream out, String toolName) {
+        this(new PrintWriter(out), toolName);
+    }
+
     // jcoder entry point
     public static void main(String... argv) {
         Main compiler = new Main(new ToolOutput.EscapedPrintStreamOutput(System.out), argv);
@@ -88,6 +112,12 @@ public class Main extends JcoderTool {
         environment.info("info.opt.v");
         environment.info("info.opt.t");
         environment.info("info.opt.version");
+    }
+
+    // Run jcoder compiler with args
+    public synchronized boolean compile(String... argv) {
+        parseArgs(argv);
+        return this.compile() == OK;
     }
 
     // Run jcoder compiler when args already parsed


### PR DESCRIPTION
This is the fix for a regression made during the fix of [CODETOOLS-7902888]( https://bugs.openjdk.org/browse/CODETOOLS-7902888)<br>
Also added extra methods to Main classes to allow working with external tools.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7902888](https://bugs.openjdk.org/browse/CODETOOLS-7902888): Excess entries in BootstrapMethods with the same bsm, bsmKind, bsmArgs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/asmtools pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/47.diff">https://git.openjdk.org/asmtools/pull/47.diff</a>

</details>
