### PR TITLE
7903536: jasm: the tool ignores options: -nowarn, -strict

### DIFF
--- a/src/org/openjdk/asmtools/common/CompilerLogger.java
+++ b/src/org/openjdk/asmtools/common/CompilerLogger.java
@@ -58,16 +58,15 @@ public class CompilerLogger extends ToolLogger implements ILogger {
 
     @Override
     public void warning(int where, String id, Object... args) {
-        EMessageKind kind = (strictWarnings) ? ERROR : WARNING;
-        Message message = getResourceString(kind, id, args);
+        Message message = getResourceString(WARNING, id, args);
         if (message.notFound()) {
             if (EMessageKind.isFromResourceBundle(id)) {
                 insert(NOWHERE, new Message(ERROR, "(I18NResourceBundle) The warning message '%s' not found", id));
             } else {
-                insert(where, new Message(kind, args.length == 0 ? id : format(id, args)));
+                insert(where, new Message((strictWarnings) ? ERROR : WARNING, args.length == 0 ? id : format(id, args)));
             }
         } else {
-            insert(where, message);
+            insert(where, strictWarnings ? new Message(ERROR, message.text()) : message);
         }
     }
 

--- a/src/org/openjdk/asmtools/common/CompilerLogger.java
+++ b/src/org/openjdk/asmtools/common/CompilerLogger.java
@@ -58,12 +58,13 @@ public class CompilerLogger extends ToolLogger implements ILogger {
 
     @Override
     public void warning(int where, String id, Object... args) {
-        Message message = getResourceString(WARNING, id, args);
+        EMessageKind kind = (strictWarnings) ? ERROR : WARNING;
+        Message message = getResourceString(kind, id, args);
         if (message.notFound()) {
             if (EMessageKind.isFromResourceBundle(id)) {
                 insert(NOWHERE, new Message(ERROR, "(I18NResourceBundle) The warning message '%s' not found", id));
             } else {
-                insert(where, new Message(WARNING, args.length == 0 ? id : format(id, args)));
+                insert(where, new Message(kind, args.length == 0 ? id : format(id, args)));
             }
         } else {
             insert(where, message);
@@ -163,6 +164,9 @@ public class CompilerLogger extends ToolLogger implements ILogger {
             int where = entry.getKey();
             Pair<Integer, Integer> filePosition = filePosition(where);
             for (Message msg : entry.getValue()) {
+                if( msg.kind() == WARNING && ignoreWarnings) {
+                   continue;
+                }
                 if (msg.kind() == ERROR) {
                     output = getOutputs().getEToolObject();
                     nErrors++;

--- a/src/org/openjdk/asmtools/common/Environment.java
+++ b/src/org/openjdk/asmtools/common/Environment.java
@@ -48,8 +48,6 @@ public abstract class Environment<T extends ToolLogger> implements ILogger {
     private boolean verboseFlag;
 
     private boolean traceFlag;
-    private boolean ignoreWarnings;         // do not print / ignore warnings
-    private boolean strictWarnings;         // consider warnings as errors
 
     /**
      * @param builder the environment builder
@@ -68,12 +66,12 @@ public abstract class Environment<T extends ToolLogger> implements ILogger {
         this.traceFlag = flag;
     }
 
-    public void setIgnoreWarnings(boolean ignoreWarnings) {
-        this.ignoreWarnings = ignoreWarnings;
+    public void setIgnoreWarningsOn() {
+        toolLogger.ignoreWarnings = true;
     }
 
-    public void setStrictWarnings(boolean strictWarnings) {
-        this.strictWarnings = strictWarnings;
+    public void setStrictWarningsOn() {
+        toolLogger.strictWarnings = true;
     }
 
     public String getSimpleInputFileName() { return toolLogger.getSimpleInputFileName(); }

--- a/src/org/openjdk/asmtools/common/ToolLogger.java
+++ b/src/org/openjdk/asmtools/common/ToolLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,9 @@ import static org.openjdk.asmtools.common.EMessageKind.ERROR;
 import static org.openjdk.asmtools.common.EMessageKind.INFO;
 
 public abstract class ToolLogger implements ILogger {
+
+    protected boolean ignoreWarnings = false;         // do not print / ignore warnings
+    protected boolean strictWarnings  = false;        // consider warnings as errors
 
     class ToolResources {
         private final static HashMap<String, I18NResourceBundle> resources = new HashMap<>();

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -173,14 +173,14 @@ public class Main extends JasmTool {
         environment.usage(List.of(
                 "info.usage",
                 "info.opt.d",
-                "info.opt.t",
-                "info.opt.v",
                 "info.opt.nowrite",
                 "info.opt.nowarn",
                 "info.opt.strict",
                 "info.opt.cv",
                 "info.opt.fixcv",
                 "info.opt.fixcv.full",
+                "info.opt.t",
+                "info.opt.v",
                 "info.opt.version"
         ));
     }
@@ -198,8 +198,8 @@ public class Main extends JasmTool {
                         setVerboseFlag(true);
                         setTraceFlag(true);
                     }
-                    case "-strict" -> environment.setStrictWarnings(true);
-                    case "-nowarn" -> environment.setIgnoreWarnings(true);
+                    case "-strict" -> environment.setStrictWarningsOn();
+                    case "-nowarn" -> environment.setIgnoreWarningsOn();
                     case "-nowrite" -> noWriteFlag = true;
                     case org.openjdk.asmtools.Main.VERSION_SWITCH -> {
                         environment.println(FULL_VERSION);

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -117,13 +117,13 @@ public class Main extends JcoderTool {
         environment.flush(false);
         environment.usage(List.of(
                 "info.usage",
+                "info.opt.d",
                 "info.opt.nowrite",
                 "info.opt.ignore",
-                "info.opt.d",
-                "info.opt.v",
-                "info.opt.t",
                 "info.opt.fixcv",
                 "info.opt.fixcv.full",
+                "info.opt.t",
+                "info.opt.v",
                 "info.opt.version"
         ));
     }

--- a/src/org/openjdk/asmtools/jdec/Main.java
+++ b/src/org/openjdk/asmtools/jdec/Main.java
@@ -84,8 +84,8 @@ public class Main extends JdecTool {
     public void usage() {
         environment.usage(List.of(
                 "info.usage",
-                "info.opt.g",
                 "info.opt.d",
+                "info.opt.g",
                 "info.opt.v",
                 "info.opt.version"));
     }

--- a/src/org/openjdk/asmtools/jdis/Main.java
+++ b/src/org/openjdk/asmtools/jdis/Main.java
@@ -127,16 +127,16 @@ public class Main extends JdisTool {
     public void usage() {
         environment.usage(List.of(
         "info.usage",
-        "info.opt.g",
-        "info.opt.sl",
-        "info.opt.lt",
-        "info.opt.lv",
-        "info.opt.nc",
-// TODO "info.opt.table",
-        "info.opt.hx",
         "info.opt.d",
-        "info.opt.v",
+        "info.opt.g",
+        "info.opt.nc",
+        "info.opt.lv",
+        "info.opt.lt",
+        "info.opt.hx",
+        "info.opt.sl",
+// TODO "info.opt.table",
         "info.opt.t",
+        "info.opt.v",
         "info.opt.version"));
     }
 


### PR DESCRIPTION
This is the fix for [CODETOOLS-7903536](https://bugs.openjdk.org/browse/CODETOOLS-7903536)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903536](https://bugs.openjdk.org/browse/CODETOOLS-7903536): jasm: the tool ignores options: -nowarn, -strict (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/asmtools.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/63.diff">https://git.openjdk.org/asmtools/pull/63.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/asmtools/pull/63#issuecomment-1690441109)