### PR TITLE
7903582: jdis incorrectly processes a class compiled with the --enable-preview option

### DIFF
--- a/maven/mvngen.sh
+++ b/maven/mvngen.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #####################################################################################################
-# Symlinks are forbidden in openjdk project, thus we generate them on the fly togehter with pom.xml #
+# Symlinks are forbidden in openjdk project, thus we generate them on the fly together with pom.xml #
 #####################################################################################################
 
 set -eo pipefail

--- a/src/org/openjdk/asmtools/common/structure/CFVersion.java
+++ b/src/org/openjdk/asmtools/common/structure/CFVersion.java
@@ -29,19 +29,19 @@ public class CFVersion {
     /**
      * Default versions of class file
      */
-    public static final short DEFAULT_MAJOR_VERSION = 45;
-    public static final short DEFAULT_MINOR_VERSION = 3;
-    public static final short DEFAULT_MODULE_MAJOR_VERSION = 53;
-    public static final short DEFAULT_MODULE_MINOR_VERSION = 0;
-    public static final short UNDEFINED_VERSION = -1;
+    public static final int DEFAULT_MAJOR_VERSION = 45;
+    public static final int DEFAULT_MINOR_VERSION = 3;
+    public static final int DEFAULT_MODULE_MAJOR_VERSION = 53;
+    public static final int DEFAULT_MODULE_MINOR_VERSION = 0;
+    public static final int UNDEFINED_VERSION = -1;
     /* The version of a class file since which the compact format of stack map is necessary */
     public static final int SPLIT_VERIFIER_CFV = 50;
 
-    private short major_version;
-    private short minor_version;
+    private int major_version;
+    private int minor_version;
 
-    private short threshold_major_version;
-    private short threshold_minor_version;
+    private int threshold_major_version;
+    private int threshold_minor_version;
 
     private boolean frozen;
 
@@ -57,7 +57,7 @@ public class CFVersion {
         threshold_minor_version = UNDEFINED_VERSION;
     }
 
-    public CFVersion(short major_version, short minor_version) {
+    public CFVersion(int major_version, int minor_version) {
         frozen = false;
         this.major_version = major_version;
         this.minor_version = minor_version;
@@ -68,19 +68,19 @@ public class CFVersion {
         return this;
     }
 
-    public CFVersion setThreshold(short major_version, short minor_version) {
+    public CFVersion setThreshold(int major_version, int minor_version) {
         this.threshold_major_version = major_version;
         this.threshold_minor_version = minor_version;
         return this;
     }
 
-    public CFVersion setVersion(short major_version, short minor_version) {
+    public CFVersion setVersion(int major_version, int minor_version) {
         this.major_version = major_version;
         this.minor_version = minor_version;
         return this;
     }
 
-    public CFVersion setFileVersion(short major_version, short minor_version) {
+    public CFVersion setFileVersion(int major_version, int minor_version) {
         if (isSet() && isFrozen()) {
             if (isThresholdSet()) {
                 if ((major_version < threshold_major_version) ||
@@ -97,13 +97,13 @@ public class CFVersion {
     }
 
 
-    public CFVersion setMajorVersion(short major_version) {
+    public CFVersion setMajorVersion(int major_version) {
         if (!frozen)
             this.major_version = major_version;
         return this;
     }
 
-    public CFVersion setMinorVersion(short minor_version) {
+    public CFVersion setMinorVersion(int minor_version) {
         if (!frozen) this.minor_version = minor_version;
         return this;
     }
@@ -172,11 +172,11 @@ public class CFVersion {
         return cfVersion;
     }
 
-    public short minor_version() {
-        return this.minor_version;
+    public int minor_version() {
+            return this.minor_version;
     }
 
-    public short major_version() {
+    public int major_version() {
         return this.major_version;
     }
 }

--- a/src/org/openjdk/asmtools/jasm/Main.java
+++ b/src/org/openjdk/asmtools/jasm/Main.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools.jasm;
 
+import org.openjdk.asmtools.asmutils.Pair;
 import org.openjdk.asmtools.common.inputs.FileInput;
 import org.openjdk.asmtools.common.inputs.ToolInput;
 import org.openjdk.asmtools.common.outputs.PrintWriterOutput;
@@ -236,13 +237,25 @@ public class Main extends JasmTool {
                                 if (versionsThreshold.length != 2 || versionsUpdate.length != 2) {
                                     throw new NumberFormatException();
                                 }
-                                cfv.setThreshold(Short.parseShort(versionsThreshold[0]), Short.parseShort(versionsThreshold[1])).
-                                        setVersion(Short.parseShort(versionsUpdate[0]), Short.parseShort(versionsUpdate[1])).
-                                        setByParameter(true).setFrozen(true);
+                                Pair<Integer, Integer> versionsPair = new Pair<>(Integer.parseInt(versionsThreshold[0]),
+                                        Integer.parseInt(versionsThreshold[1]));
+                                if( versionsPair.second > 0xFFFF || versionsPair.first > 0xFFFF ) {
+                                    throw new NumberFormatException();
+                                }
+                                cfv.setThreshold(versionsPair.first, versionsPair.second);
+                                versionsPair = new Pair<>(Integer.parseInt(versionsUpdate[0]), Integer.parseInt(versionsUpdate[1]));
+                                if( versionsPair.second > 0xFFFF || versionsPair.first > 0xFFFF ) {
+                                    throw new NumberFormatException();
+                                }
+                                cfv.setVersion(versionsPair.first, versionsPair.second).setByParameter(true).setFrozen(true);
                             } else {
                                 String[] versions = cfvArg.split("[.:]+", 2);
                                 if (versions.length == 2) {
-                                    cfv.setVersion(Short.parseShort(versions[0]), Short.parseShort(versions[1])).
+                                    Pair<Integer, Integer> versionsPair = new Pair<>(Integer.parseInt(versions[0]), Integer.parseInt(versions[1]));
+                                    if( versionsPair.second > 0xFFFF || versionsPair.first > 0xFFFF ) {
+                                        throw new NumberFormatException();
+                                    }
+                                    cfv.setVersion(Integer.parseInt(versions[0]), Integer.parseInt(versions[1])).
                                             setByParameter(true).setFrozen(frozenCFV);
                                 } else {
                                     throw new NumberFormatException();
@@ -253,7 +266,6 @@ public class Main extends JasmTool {
                                 environment.error("err.invalid_threshold_major_minor_param");
                             } else {
                                 environment.error("err.invalid_major_minor_param");
-
                             }
                             usage();
                             throw new IllegalArgumentException();

--- a/src/org/openjdk/asmtools/jasm/Parser.java
+++ b/src/org/openjdk/asmtools/jasm/Parser.java
@@ -121,16 +121,16 @@ class Parser extends ParseBase {
     }
 
     private void parseVersion() {
-        short majorVersion, minorVersion;
+        int majorVersion, minorVersion;
         if (scanner.token == Token.VERSION) {
             scanner.scan();
             if (scanner.token == Token.INTVAL) {
-                majorVersion = (short) scanner.intValue;
+                majorVersion = scanner.intValue;
                 scanner.scan();
                 if (scanner.token == Token.COLON) {
                     scanner.scan();
                     if (scanner.token == Token.INTVAL) {
-                        minorVersion = (short) scanner.intValue;
+                        minorVersion = scanner.intValue;
                         classData.cfv.setFileVersion(majorVersion, minorVersion);
                         scanner.scan();
                         traceMethodInfoLn("parseVersion: " + classData.cfv.asString());
@@ -1546,8 +1546,8 @@ class Parser extends ParseBase {
             }
         } else {
             if (classData.cfv.isSet() && classData.cfv.isSetByParameter() && classData.cfv.isFrozen()) {
-                short minor = classData.cfv.minor_version();
-                short major = classData.cfv.major_version();
+                int minor = classData.cfv.minor_version();
+                int major = classData.cfv.major_version();
                 String version =  classData.cfv.asString();
                 String option = classData.cfv.isThresholdSet() ? classData.cfv.asThresholdString() : classData.cfv.asString();
                 parseVersion();

--- a/src/org/openjdk/asmtools/jasm/i18n.properties
+++ b/src/org/openjdk/asmtools/jasm/i18n.properties
@@ -39,7 +39,7 @@ info.opt.fixcv.full=\
 err.cv_requires_arg=-cv option requires the argument <major.minor>
 err.fix_cv_requires_arg=-fixcv option requires the argument either <major.minor> or <major.minor>-<major.minor>
 err.invalid_major_minor_param=Invalid parameter <major.minor>
-err.invalid_threshold_major_minor_param=Invalid parameter \"-fixvc '{<major.minor>-}'<major.minor>\"
+err.invalid_threshold_major_minor_param=Invalid parameter \"-fixcv '{<major.minor>-}'<major.minor>\"
 err.invalid_option=Invalid option: {0}
 err.byte.limit=Unspecified byte-limit
 

--- a/src/org/openjdk/asmtools/jcoder/Main.java
+++ b/src/org/openjdk/asmtools/jcoder/Main.java
@@ -22,6 +22,7 @@
  */
 package org.openjdk.asmtools.jcoder;
 
+import org.openjdk.asmtools.asmutils.Pair;
 import org.openjdk.asmtools.common.inputs.FileInput;
 import org.openjdk.asmtools.common.inputs.ToolInput;
 import org.openjdk.asmtools.common.outputs.PrintWriterOutput;
@@ -216,31 +217,42 @@ public class Main extends JcoderTool {
                             usage();
                             throw new IllegalArgumentException();
                         }
+                        String cfvArg = argv[++i];
+                        boolean withThreshold = cfvArg.contains("-");
                         try {
-
-                            String cfvArg = argv[++i];
-                            if (cfvArg.contains("-")) {
+                            if (withThreshold) {
                                 String[] versions = cfvArg.split("-", 2);
                                 String[] versionsThreshold = versions[0].split("[.:]+", 2);
                                 String[] versionsUpdate = versions[1].split("[.:]+", 2);
                                 if (versionsThreshold.length != 2 || versionsUpdate.length != 2) {
                                     throw new NumberFormatException();
                                 }
-                                environment.cfv.setThreshold(Short.parseShort(versionsThreshold[0]), Short.parseShort(versionsThreshold[1])).
-                                        setVersion(Short.parseShort(versionsUpdate[0]), Short.parseShort(versionsUpdate[1])).
-                                        setByParameter(true).setFrozen(true);
-
+                                Pair<Integer, Integer> versionsPair = new Pair<>(Integer.parseInt(versionsThreshold[0]),
+                                        Integer.parseInt(versionsThreshold[1]));
+                                if( versionsPair.second > 0xFFFF || versionsPair.first > 0xFFFF ) {
+                                    throw new NumberFormatException();
+                                }
+                                environment.cfv.setThreshold(versionsPair.first, versionsPair.second);
+                                versionsPair = new Pair<>(Integer.parseInt(versionsUpdate[0]), Integer.parseInt(versionsUpdate[1]));
+                                if( versionsPair.second > 0xFFFF || versionsPair.first > 0xFFFF ) {
+                                    throw new NumberFormatException();
+                                }
+                                environment.cfv.setVersion(versionsPair.first, versionsPair.second).setByParameter(true).setFrozen(true);
                             } else {
                                 String[] versions = cfvArg.split("[.:]+", 2);
                                 if (versions.length == 2) {
-                                    environment.cfv.setVersion(Short.parseShort(versions[0]), Short.parseShort(versions[1])).
+                                    Pair<Integer, Integer> versionsPair = new Pair<>(Integer.parseInt(versions[0]), Integer.parseInt(versions[1]));
+                                    if( versionsPair.second > 0xFFFF || versionsPair.first > 0xFFFF ) {
+                                        throw new NumberFormatException();
+                                    }
+                                    environment.cfv.setVersion(Integer.parseInt(versions[0]), Integer.parseInt(versions[1])).
                                             setByParameter(true).setFrozen(true);
                                 } else {
                                     throw new NumberFormatException();
                                 }
                             }
                         } catch (PatternSyntaxException | NumberFormatException exception) {
-                            environment.error("err.invalid_threshold_major_minor_param");
+                                environment.error("err.invalid_threshold_major_minor_param");
                             usage();
                             throw new IllegalArgumentException();
                         }

--- a/src/org/openjdk/asmtools/jdis/ClassData.java
+++ b/src/org/openjdk/asmtools/jdis/ClassData.java
@@ -285,8 +285,8 @@ public class ClassData extends MemberData<ClassData> {
                 throw new ClassCastException("wrong magic: " + HexUtils.toHex(magic) + ", expected " + HexUtils.toHex(JAVA_MAGIC));
             }
 
-            cfVersion.setMinorVersion((short) in.readUnsignedShort());
-            cfVersion.setMajorVersion((short) in.readUnsignedShort());
+            cfVersion.setMinorVersion( in.readUnsignedShort());
+            cfVersion.setMajorVersion( in.readUnsignedShort());
 
             // Read the constant pool
             pool.read(in);


### PR DESCRIPTION
This is the fix for [CODETOOLS-7903582](https://bugs.openjdk.org/browse/CODETOOLS-7903582)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903582](https://bugs.openjdk.org/browse/CODETOOLS-7903582): jdis incorrectly processes a class compiled with the --enable-preview option (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools.git pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/asmtools.git pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/69.diff">https://git.openjdk.org/asmtools/pull/69.diff</a>

</details>
