### PR TITLE
added jdk21 to test matrix

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - at8
+      - at7
   pull_request:
     branches:
       - master
-      - at8
+      - at7
   workflow_dispatch:
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java-version: [ 17 ]
+        java-version: [ 17, 21 ]
       fail-fast: false
 
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven


### PR DESCRIPTION
This is adding jdk21 to jdk test matrix and removing at8 branch, which is no longer used
I had not added at7 branch.
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Error
&nbsp;⚠️ The pull request body must not be empty.

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/asmtools.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/72.diff">https://git.openjdk.org/asmtools/pull/72.diff</a>

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools.git pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.org/asmtools.git pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/72.diff">https://git.openjdk.org/asmtools/pull/72.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/asmtools/pull/72#issuecomment-1898533209)