### PR TITLE
7903806: Enhance jasm/jdis to support value classes and objects

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
       - master
-      - at7
   pull_request:
     branches:
       - master
-      - at7
   workflow_dispatch:
 
 jobs:
@@ -18,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        java-version: [ 17, 21 ]
+        java-version: [ 21, 24 ]
       fail-fast: false
 
     name: ${{ matrix.os }} - Java ${{ matrix.java-version }} - Maven

--- a/src/org/openjdk/asmtools/jasm/ArrayAttr.java
+++ b/src/org/openjdk/asmtools/jasm/ArrayAttr.java
@@ -62,7 +62,7 @@ public class ArrayAttr extends AttrData {
     public ArrayAttr(ConstantPool pool, EAttribute attribute, List<ConstCell> constCellList) {
         super(pool, attribute);
         for (ConstCell<?> cell : constCellList) {
-            this.cells.add(classifyConstCell(pool, cell));
+            this.cells.add(cell);
         }
     }
 

--- a/src/org/openjdk/asmtools/jasm/ParseAttribute.java
+++ b/src/org/openjdk/asmtools/jasm/ParseAttribute.java
@@ -314,9 +314,6 @@ public class ParseAttribute extends ParseBase {
                 }
                 case RBRACE -> {
                     if (wrapLevel == 0) {
-//                        if (entryType == EARLY_LARVAL) {
-//                            environment.throwErrorException(scanner.pos, "err.base.frame.expected");
-//                        }
                         return list;
                     }
                     wrapLevel--;
@@ -362,11 +359,6 @@ public class ParseAttribute extends ParseBase {
                                 stackMapData = new StackMapData(environment, parser.curCodeAttr.isTypeCheckingVerifier());
                                 environment.warning(scanner.pos, "warn.stackmap.expected",
                                         "\"%s\"".formatted(expectedToken.parseKey()));
-//                            } else if (expectedToken == UNSETFIELDS) {
-//                                // missing means empty unset_fields
-//                                stackMapData.unsetFields = new DataVector<>();
-//                                list.add(stackMapData);
-//                                stackMapData = new StackMapData(environment, parser.curCodeAttr.isTypeCheckingVerifier());
                         } else {
                                 environment.throwErrorException(scanner.pos, "err.stackmap.expected",
                                         "\"%s\"".formatted(expectedToken.parseKey()));
@@ -561,11 +553,6 @@ public class ParseAttribute extends ParseBase {
                         continue;
                     }
                 }
-//                default -> {
-//                    if (wrapLevel == 0) {
-//                        environment.throwErrorException(scanner.pos, "err.token.expected", RBRACE.parseKey());
-//                    }
-//                }
             }
             scanner.scan();
         }

--- a/src/org/openjdk/asmtools/jdis/ClassArrayData.java
+++ b/src/org/openjdk/asmtools/jdis/ClassArrayData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ public class ClassArrayData extends MemberData {
 
     @Override
     public void jasmPrint() {
-        if (indexes.length > 3) {
+        if (indexes.length > 2) {
             jasmPrintLong();
         } else {
             jasmPrintShort();

--- a/test/java/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsTests.java
+++ b/test/java/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsTests.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.asmtools.attribute.LoadableDescriptors;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openjdk.asmtools.common.inputs.StringInput;
+import org.openjdk.asmtools.lib.action.*;
+import org.openjdk.asmtools.lib.log.LogAndBinResults;
+import org.openjdk.asmtools.lib.log.LogAndTextResults;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static org.openjdk.asmtools.lib.utility.StringUtils.funcSubStrCount;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class LoadableDescriptorsTests {
+
+    private Jasm jasm = new Jasm();
+    private Jcoder jcoder = new Jcoder();
+    private File resourceDir;
+
+    private static Stream<Arguments> getJasmParameters() {
+        return Stream.of(
+                Arguments.of("LoadableDescriptorsAttributeTest$X.jasm", EToolArguments.JDIS, List.of(
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "LoadableDescriptors ") == 1,
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "strict") == 3
+
+                        )
+                ),
+                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jasm", EToolArguments.JDIS_G_T, List.of(
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "LoadableDescriptors ") == 1,
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "strict") == 3
+
+                        )
+                ),
+                Arguments.of("LoadableDescriptorsAttributeTest$X.g.t.jasm", EToolArguments.JDIS_G, List.of(
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "LoadableDescriptors ") == 1,
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "strict") == 3
+                        )
+                )
+        );
+    }
+
+    private static Stream<Arguments> getJcodParameters() {
+        return Stream.of(
+                Arguments.of("LoadableDescriptorsAttributeTest$X.jcod", EToolArguments.JDEC_G, List.of(
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "LoadableDescriptors ") == 1
+                        )
+                ),
+                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jcod", EToolArguments.JDEC, List.of(
+                                (Function<String, Boolean>) (text) -> funcSubStrCount.apply(text, "LoadableDescriptors") == 26
+                        )
+                )
+        );
+    }
+
+    @BeforeAll
+    public void init() throws IOException {
+        resourceDir = new File(Objects.requireNonNull(this.getClass().
+                getResource("LoadableDescriptorsAttributeTest$X.jasm")).getFile()).getParentFile();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getJasmParameters")
+    public void jasmTest(String resourceName, EToolArguments args, List<Function<String, Boolean>> tests) {
+        // jasm to class in memory
+        LogAndBinResults binResult = jasm.compile(List.of(resourceDir + File.separator + resourceName));
+        // class produced correctly
+        Assertions.assertTrue(binResult.log.toString().isEmpty());
+        Assertions.assertEquals(0, binResult.result);
+
+        // class to jasm
+        LogAndTextResults textResult = new Jdis().setArgs(args).decode(binResult.getAsByteInput());
+
+        Assertions.assertEquals(0, textResult.result);
+        String jasmText = textResult.getResultAsString(Function.identity());
+        for (Function<String, Boolean> testFunction : tests) {
+            Assertions.assertTrue(testFunction.apply(jasmText));
+        }
+        // jasm to class
+        binResult = jasm.compile(new StringInput(jasmText));
+        // class produced correctly
+        Assertions.assertTrue(binResult.log.toString().isEmpty());
+        Assertions.assertEquals(0, binResult.result);
+        // class to jasm
+        textResult = new Jdis().setArgs(args).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+        jasmText = textResult.getResultAsString(Function.identity());
+        for (Function<String, Boolean> testFunction : tests) {
+            Assertions.assertTrue(testFunction.apply(jasmText));
+        }
+        // class to jcod
+        textResult = new Jdec().setArgs(EToolArguments.JDEC_G).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+        // jcod to class
+        binResult = jcoder.compile(new StringInput(textResult.getResultAsString(Function.identity())));
+        Assertions.assertEquals(0, binResult.result);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getJcodParameters")
+    public void jcoderTest(String resourceName, EToolArguments args, List<Function<String, Boolean>> tests) {
+        // jcod to class in memory
+        LogAndBinResults binResult = jcoder.compile(List.of(resourceDir + File.separator + resourceName));
+        // class produced correctly
+        Assertions.assertEquals(0, binResult.result);
+        Assertions.assertTrue(binResult.log.toString().isEmpty());
+        // class to jcod
+        LogAndTextResults textResult = new Jdec().setArgs(args).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+        for (Function<String, Boolean> testFunction : tests) {
+            Assertions.assertTrue(testFunction.apply(textResult.getResultAsString(Function.identity())));
+        }
+        // class to jasm twice
+        textResult = new Jdis().setArgs(EToolArguments.JDIS_G_T_LNT_LVT).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+        textResult = new Jdis().setArgs(EToolArguments.JDIS_GG_NC_LNT_LVT).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+    }
+}

--- a/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.g.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.g.jasm
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+final class #2 /* LoadableDescriptorsAttributeTest$X */ version 69:65535
+{
+  const #1   = Field       #2.#3;               // LoadableDescriptorsAttributeTest$X.v1:"[LLoadableDescriptorsAttributeTest$V1;"
+  const #2   = class       #4;                  // LoadableDescriptorsAttributeTest$X
+  const #3   = NameAndType #5:#6;               // v1:"[LLoadableDescriptorsAttributeTest$V1;"
+  const #4   = Utf8        "LoadableDescriptorsAttributeTest$X";
+  const #5   = Utf8        "v1";
+  const #6   = Utf8        "[LLoadableDescriptorsAttributeTest$V1;";
+  const #7   = Field       #2.#8;               // LoadableDescriptorsAttributeTest$X.v7:"LLoadableDescriptorsAttributeTest$V7;"
+  const #8   = NameAndType #9:#10;              // v7:"LLoadableDescriptorsAttributeTest$V7;"
+  const #9   = Utf8        "v7";
+  const #10  = Utf8        "LLoadableDescriptorsAttributeTest$V7;";
+  const #11  = Field       #2.#12;              // LoadableDescriptorsAttributeTest$X.v10:"LLoadableDescriptorsAttributeTest$V10;"
+  const #12  = NameAndType #13:#14;             // v10:"LLoadableDescriptorsAttributeTest$V10;"
+  const #13  = Utf8        "v10";
+  const #14  = Utf8        "LLoadableDescriptorsAttributeTest$V10;";
+  const #15  = Method      #16.#17;             // java/lang/Object."<init>":"()V"
+  const #16  = class       #18;                 // java/lang/Object
+  const #17  = NameAndType #19:#20;             // "<init>":"()V"
+  const #18  = Utf8        "java/lang/Object";
+  const #19  = Utf8        "<init>";
+  const #20  = Utf8        "()V";
+  const #21  = Utf8        "Code";
+  const #22  = Utf8        "LineNumberTable";
+  const #23  = Utf8        "foo";
+  const #24  = Utf8        "()LLoadableDescriptorsAttributeTest$V2;";
+  const #25  = Utf8        "(LLoadableDescriptorsAttributeTest$V3;)V";
+  const #26  = Utf8        "(I)V";
+  const #27  = Utf8        "goo";
+  const #28  = Utf8        "([LLoadableDescriptorsAttributeTest$V6;)V";
+  const #29  = Utf8        "StackMapTable";
+  const #30  = class       #31;                 // LoadableDescriptorsAttributeTest$V5
+  const #31  = Utf8        "LoadableDescriptorsAttributeTest$V5";
+  const #32  = Utf8        "([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;";
+  const #33  = Utf8        "SourceFile";
+  const #34  = Utf8        "LoadableDescriptorsAttributeTest.java";
+  const #35  = Utf8        "NestHost";
+  const #36  = class       #37;                 // LoadableDescriptorsAttributeTest
+  const #37  = Utf8        "LoadableDescriptorsAttributeTest";
+  const #38  = Utf8        "InnerClasses";
+  const #39  = Utf8        "X";
+  const #40  = class       #41;                 // LoadableDescriptorsAttributeTest$V1
+  const #41  = Utf8        "LoadableDescriptorsAttributeTest$V1";
+  const #42  = Utf8        "V1";
+  const #43  = class       #44;                 // LoadableDescriptorsAttributeTest$V7
+  const #44  = Utf8        "LoadableDescriptorsAttributeTest$V7";
+  const #45  = Utf8        "V7";
+  const #46  = class       #47;                 // LoadableDescriptorsAttributeTest$V10
+  const #47  = Utf8        "LoadableDescriptorsAttributeTest$V10";
+  const #48  = Utf8        "V10";
+  const #49  = class       #50;                 // LoadableDescriptorsAttributeTest$V2
+  const #50  = Utf8        "LoadableDescriptorsAttributeTest$V2";
+  const #51  = Utf8        "V2";
+  const #52  = class       #53;                 // LoadableDescriptorsAttributeTest$V3
+  const #53  = Utf8        "LoadableDescriptorsAttributeTest$V3";
+  const #54  = Utf8        "V3";
+  const #55  = class       #56;                 // LoadableDescriptorsAttributeTest$V6
+  const #56  = Utf8        "LoadableDescriptorsAttributeTest$V6";
+  const #57  = Utf8        "V6";
+  const #58  = Utf8        "V5";
+  const #59  = class       #60;                 // LoadableDescriptorsAttributeTest$V9
+  const #60  = Utf8        "LoadableDescriptorsAttributeTest$V9";
+  const #61  = Utf8        "V9";
+  const #62  = class       #63;                 // LoadableDescriptorsAttributeTest$V8
+  const #63  = Utf8        "LoadableDescriptorsAttributeTest$V8";
+  const #64  = Utf8        "V8";
+  const #65  = Utf8        "LoadableDescriptors";
+  const #66  = Utf8        "LLoadableDescriptorsAttributeTest$V3;";
+  const #67  = Utf8        "LLoadableDescriptorsAttributeTest$V2;";
+
+  final strict Field #5:#6;                     // v1:"[LLoadableDescriptorsAttributeTest$V1;"
+  final strict Field #9:#10;                    // v7:"LLoadableDescriptorsAttributeTest$V7;"
+  final strict Field #13:#14;                   // v10:"LLoadableDescriptorsAttributeTest$V10;"
+
+  Method       #19:#20                          // "<init>":"()V"
+    stack 2  locals 1
+  {
+     0:    aload_0;
+     1:    aconst_null;
+     2:    putfield          #1;                // Field v1:"[LLoadableDescriptorsAttributeTest$V1;"
+     5:    aload_0;
+     6:    aconst_null;
+     7:    putfield          #7;                // Field v7:"LLoadableDescriptorsAttributeTest$V7;"
+    10:    aload_0;
+    11:    aconst_null;
+    12:    putfield          #11;               // Field v10:"LLoadableDescriptorsAttributeTest$V10;"
+    15:    aload_0;
+    16:    invokespecial     #15;               // Method java/lang/Object."<init>":"()V"
+    19:    return;
+  }
+
+  Method       #23:#24                          // foo:"()LLoadableDescriptorsAttributeTest$V2;"
+    stack 1  locals 1
+  {
+     0:    aconst_null;
+     1:    areturn;
+  }
+
+  Method       #23:#25                          // foo:"(LLoadableDescriptorsAttributeTest$V3;)V"
+    stack 0  locals 2
+  {
+     0:    return;
+  }
+
+  Method       #23:#26                          // foo:"(I)V"
+    stack 1  locals 3
+  {
+     0:    aconst_null;
+     1:    astore_2;
+     2:    return;
+  }
+
+  Method       #27:#28                          // goo:"([LLoadableDescriptorsAttributeTest$V6;)V"
+    stack 1  locals 4
+  {
+     0:    aconst_null;
+     1:    astore_2;
+     2:    aload_2;
+     3:    ifnonnull         9;
+     6:    goto              11;
+     9:    stack_frame_type  append;            // frame_type 252
+             locals_map      #30;               // class LoadableDescriptorsAttributeTest$V5;
+           aconst_null;
+    10:    astore_3;
+    11:    stack_frame_type  same;              // frame_type 1
+           return;
+  }
+
+  Method       #27:#32                          // goo:"([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;"
+    stack 1  locals 2
+  {
+     0:    aconst_null;
+     1:    areturn;
+  }
+
+  SourceFile                 #34;               // LoadableDescriptorsAttributeTest.java
+
+  NestHost                   #36;               // LoadableDescriptorsAttributeTest
+
+  InnerClass                 static final #39 = #2 of #36;  // X = class LoadableDescriptorsAttributeTest$X of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #42 = #40 of #36;        // V1 = class LoadableDescriptorsAttributeTest$V1 of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #45 = #43 of #36;        // V7 = class LoadableDescriptorsAttributeTest$V7 of class LoadableDescriptorsAttributeTest
+  InnerClass                 abstract #48 = #46 of #36;     // V10 = class LoadableDescriptorsAttributeTest$V10 of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #51 = #49 of #36;        // V2 = class LoadableDescriptorsAttributeTest$V2 of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #54 = #52 of #36;        // V3 = class LoadableDescriptorsAttributeTest$V3 of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #57 = #55 of #36;        // V6 = class LoadableDescriptorsAttributeTest$V6 of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #58 = #30 of #36;        // V5 = class LoadableDescriptorsAttributeTest$V5 of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #61 = #59 of #36;        // V9 = class LoadableDescriptorsAttributeTest$V9 of class LoadableDescriptorsAttributeTest
+  InnerClass                 final #64 = #62 of #36;        // V8 = class LoadableDescriptorsAttributeTest$V8 of class LoadableDescriptorsAttributeTest
+
+  LoadableDescriptors        #66, #10, #67;     // "LLoadableDescriptorsAttributeTest$V3;", "LLoadableDescriptorsAttributeTest$V7;", "LLoadableDescriptorsAttributeTest$V2;"
+} // end Class LoadableDescriptorsAttributeTest$X compiled from "LoadableDescriptorsAttributeTest.java"

--- a/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.g.jcod
+++ b/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.g.jcod
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+class LoadableDescriptorsAttributeTest$X {
+  0xCAFEBABE;
+  65535;                                   // minor version
+  69;                                      // version
+  [68] {                                   // Constant Pool
+    ;                                      // first element is empty
+    Field #2 #3;                           // #1     at 0x0A
+    Class #4;                              // #2     at 0x0F
+    NameAndType #5 #6;                     // #3     at 0x12
+    Utf8 "LoadableDescriptorsAttributeTest$X";  // #4     at 0x17
+    Utf8 "v1";                             // #5     at 0x3C
+    Utf8 "[LLoadableDescriptorsAttributeTest$V1;";  // #6     at 0x41
+    Field #2 #8;                           // #7     at 0x6A
+    NameAndType #9 #10;                    // #8     at 0x6F
+    Utf8 "v7";                             // #9     at 0x74
+    Utf8 "LLoadableDescriptorsAttributeTest$V7;";  // #10     at 0x79
+    Field #2 #12;                          // #11     at 0xA1
+    NameAndType #13 #14;                   // #12     at 0xA6
+    Utf8 "v10";                            // #13     at 0xAB
+    Utf8 "LLoadableDescriptorsAttributeTest$V10;";  // #14     at 0xB1
+    Method #16 #17;                        // #15     at 0xDA
+    Class #18;                             // #16     at 0xDF
+    NameAndType #19 #20;                   // #17     at 0xE2
+    Utf8 "java/lang/Object";               // #18     at 0xE7
+    Utf8 "<init>";                         // #19     at 0xFA
+    Utf8 "()V";                            // #20     at 0x0103
+    Utf8 "Code";                           // #21     at 0x0109
+    Utf8 "LineNumberTable";                // #22     at 0x0110
+    Utf8 "foo";                            // #23     at 0x0122
+    Utf8 "()LLoadableDescriptorsAttributeTest$V2;";  // #24     at 0x0128
+    Utf8 "(LLoadableDescriptorsAttributeTest$V3;)V";  // #25     at 0x0152
+    Utf8 "(I)V";                           // #26     at 0x017D
+    Utf8 "goo";                            // #27     at 0x0184
+    Utf8 "([LLoadableDescriptorsAttributeTest$V6;)V";  // #28     at 0x018A
+    Utf8 "StackMapTable";                  // #29     at 0x01B6
+    Class #31;                             // #30     at 0x01C6
+    Utf8 "LoadableDescriptorsAttributeTest$V5";  // #31     at 0x01C9
+    Utf8 "([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;";  // #32     at 0x01EF
+    Utf8 "SourceFile";                     // #33     at 0x0240
+    Utf8 "LoadableDescriptorsAttributeTest.java";  // #34     at 0x024D
+    Utf8 "NestHost";                       // #35     at 0x0275
+    Class #37;                             // #36     at 0x0280
+    Utf8 "LoadableDescriptorsAttributeTest";  // #37     at 0x0283
+    Utf8 "InnerClasses";                   // #38     at 0x02A6
+    Utf8 "X";                              // #39     at 0x02B5
+    Class #41;                             // #40     at 0x02B9
+    Utf8 "LoadableDescriptorsAttributeTest$V1";  // #41     at 0x02BC
+    Utf8 "V1";                             // #42     at 0x02E2
+    Class #44;                             // #43     at 0x02E7
+    Utf8 "LoadableDescriptorsAttributeTest$V7";  // #44     at 0x02EA
+    Utf8 "V7";                             // #45     at 0x0310
+    Class #47;                             // #46     at 0x0315
+    Utf8 "LoadableDescriptorsAttributeTest$V10";  // #47     at 0x0318
+    Utf8 "V10";                            // #48     at 0x033F
+    Class #50;                             // #49     at 0x0345
+    Utf8 "LoadableDescriptorsAttributeTest$V2";  // #50     at 0x0348
+    Utf8 "V2";                             // #51     at 0x036E
+    Class #53;                             // #52     at 0x0373
+    Utf8 "LoadableDescriptorsAttributeTest$V3";  // #53     at 0x0376
+    Utf8 "V3";                             // #54     at 0x039C
+    Class #56;                             // #55     at 0x03A1
+    Utf8 "LoadableDescriptorsAttributeTest$V6";  // #56     at 0x03A4
+    Utf8 "V6";                             // #57     at 0x03CA
+    Utf8 "V5";                             // #58     at 0x03CF
+    Class #60;                             // #59     at 0x03D4
+    Utf8 "LoadableDescriptorsAttributeTest$V9";  // #60     at 0x03D7
+    Utf8 "V9";                             // #61     at 0x03FD
+    Class #63;                             // #62     at 0x0402
+    Utf8 "LoadableDescriptorsAttributeTest$V8";  // #63     at 0x0405
+    Utf8 "V8";                             // #64     at 0x042B
+    Utf8 "LoadableDescriptors";            // #65     at 0x0430
+    Utf8 "LLoadableDescriptorsAttributeTest$V3;";  // #66     at 0x0446
+    Utf8 "LLoadableDescriptorsAttributeTest$V2;";  // #67     at 0x046E
+  }                                        // end of Constant Pool
+
+  0x0010;                                  // access [ ACC_FINAL ]
+  #2;                                      // this_cpx
+  #16;                                     // super_cpx
+
+  [0] {                                    // Interfaces
+  }                                        // end of Interfaces
+
+  [3] {                                    // Fields
+    {                                      // field at 0x04A0
+      0x0810;                              // access
+      #5;                                  // name_index       : v1
+      #6;                                  // descriptor_index : [LLoadableDescriptorsAttributeTest$V1;
+      [0] {                                // Attributes
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // field at 0x04A8
+      0x0810;                              // access
+      #9;                                  // name_index       : v7
+      #10;                                 // descriptor_index : LLoadableDescriptorsAttributeTest$V7;
+      [0] {                                // Attributes
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // field at 0x04B0
+      0x0810;                              // access
+      #13;                                 // name_index       : v10
+      #14;                                 // descriptor_index : LLoadableDescriptorsAttributeTest$V10;
+      [0] {                                // Attributes
+      }                                    // end of Attributes
+    }
+  }                                        // end of Fields
+
+  [6] {                                    // Methods
+    {                                      // method at 0x04BA
+      0x0000;                              // access
+      #19;                                 // name_index       : <init>
+      #20;                                 // descriptor_index : ()V
+      [1] {                                // Attributes
+        Attr(#21, 60) {                    // Code at 0x04C2
+          2;                               // max_stack
+          1;                               // max_locals
+          Bytes[20]{
+            0x2A 0x01 0xB5 0x00 0x01 0x2A 0x01 0xB5 0x00 0x07 0x2A 0x01;
+            0xB5 0x00 0x0B 0x2A 0xB7 0x00 0x0F 0xB1;
+          }
+          [0] {                            // Traps
+          }                                // end of Traps
+          [1] {                            // Attributes
+            Attr(#22, 22) {                // LineNumberTable at 0x04E8
+              [5] {                        // line_number_table
+                   0   50;                 // at 0x04F4
+                   5   67;                 // at 0x04F8
+                  10   71;                 // at 0x04FC
+                  15   49;                 // at 0x0500
+                  19   71;                 // at 0x0504
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method at 0x0504
+      0x0000;                              // access
+      #23;                                 // name_index       : foo
+      #24;                                 // descriptor_index : ()LLoadableDescriptorsAttributeTest$V2;
+      [1] {                                // Attributes
+        Attr(#21, 26) {                    // Code at 0x050C
+          1;                               // max_stack
+          1;                               // max_locals
+          Bytes[2]{
+            0x01 0xB0;
+          }
+          [0] {                            // Traps
+          }                                // end of Traps
+          [1] {                            // Attributes
+            Attr(#22, 6) {                 // LineNumberTable at 0x0520
+              [1] {                        // line_number_table
+                   0   52;                 // at 0x052C
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method at 0x052C
+      0x0000;                              // access
+      #23;                                 // name_index       : foo
+      #25;                                 // descriptor_index : (LLoadableDescriptorsAttributeTest$V3;)V
+      [1] {                                // Attributes
+        Attr(#21, 25) {                    // Code at 0x0534
+          0;                               // max_stack
+          2;                               // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] {                            // Traps
+          }                                // end of Traps
+          [1] {                            // Attributes
+            Attr(#22, 6) {                 // LineNumberTable at 0x0547
+              [1] {                        // line_number_table
+                   0   55;                 // at 0x0553
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method at 0x0553
+      0x0000;                              // access
+      #23;                                 // name_index       : foo
+      #26;                                 // descriptor_index : (I)V
+      [1] {                                // Attributes
+        Attr(#21, 31) {                    // Code at 0x055B
+          1;                               // max_stack
+          3;                               // max_locals
+          Bytes[3]{
+            0x01 0x4D 0xB1;
+          }
+          [0] {                            // Traps
+          }                                // end of Traps
+          [1] {                            // Attributes
+            Attr(#22, 10) {                // LineNumberTable at 0x0570
+              [2] {                        // line_number_table
+                   0   57;                 // at 0x057C
+                   2   58;                 // at 0x0580
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method at 0x0580
+      0x0000;                              // access
+      #27;                                 // name_index       : goo
+      #28;                                 // descriptor_index : ([LLoadableDescriptorsAttributeTest$V6;)V
+      [1] {                                // Attributes
+        Attr(#21, 63) {                    // Code at 0x0588
+          1;                               // max_stack
+          4;                               // max_locals
+          Bytes[12]{
+            0x01 0x4D 0x2C 0xC7 0x00 0x06 0xA7 0x00 0x05 0x01 0x4E 0xB1;
+;
+          }
+          [0] {                            // Traps
+          }                                // end of Traps
+          [2] {                            // Attributes
+            Attr(#22, 18) {                // LineNumberTable at 0x05A6
+              [4] {                        // line_number_table
+                   0   60;                 // at 0x05B2
+                   2   61;                 // at 0x05B6
+                   9   64;                 // at 0x05BA
+                  11   66;                 // at 0x05BE
+              }
+            }                              // end of LineNumberTable
+            ;
+            Attr(#29, 9) {                 // StackMapTable at 0x05BE
+              [2] {                        //
+                252b, 9, [1]z{7b,#30};     // append_frame 1
+                1b;                        // same_frame
+              }
+            }                              // end of StackMapTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method at 0x05CD
+      0x0000;                              // access
+      #27;                                 // name_index       : goo
+      #32;                                 // descriptor_index : ([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;
+      [1] {                                // Attributes
+        Attr(#21, 26) {                    // Code at 0x05D5
+          1;                               // max_stack
+          2;                               // max_locals
+          Bytes[2]{
+            0x01 0xB0;
+          }
+          [0] {                            // Traps
+          }                                // end of Traps
+          [1] {                            // Attributes
+            Attr(#22, 6) {                 // LineNumberTable at 0x05E9
+              [1] {                        // line_number_table
+                   0   69;                 // at 0x05F5
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+  }                                        // end of Methods
+
+  [4] {                                    // Attributes
+    Attr(#33, 2) {                         // SourceFile at 0x05F7
+      #34;
+    }                                      // end of SourceFile
+    ;
+    Attr(#35, 2) {                         // NestHost at 0x05FF
+      #36;                                 // class: LoadableDescriptorsAttributeTest at 0x0607
+    }                                      // end of NestHost
+    ;
+    Attr(#38, 82) {                        // InnerClasses at 0x0607
+      [10] {                               // classes
+           #2   #36   #39  24;             // access [ ACC_STATIC, ACC_FINAL ]
+          #40   #36   #42  16;             // access [ ACC_FINAL ]
+          #43   #36   #45  16;             // access [ ACC_FINAL ]
+          #46   #36   #48 1024;            // access [ ACC_ABSTRACT ]
+          #49   #36   #51  16;             // access [ ACC_FINAL ]
+          #52   #36   #54  16;             // access [ ACC_FINAL ]
+          #55   #36   #57  16;             // access [ ACC_FINAL ]
+          #30   #36   #58  16;             // access [ ACC_FINAL ]
+          #59   #36   #61  16;             // access [ ACC_FINAL ]
+          #62   #36   #64  16;             // access [ ACC_FINAL ]
+      }
+    }                                      // end of InnerClasses
+    ;
+    Attr(#65, 8) {                         // LoadableDescriptors at 0x065F
+      [3] {                                // Utf8
+        #66;                               // descriptor: LLoadableDescriptorsAttributeTest$V3; at 0x0669
+        #10;                               // descriptor: LLoadableDescriptorsAttributeTest$V7; at 0x066B
+        #67;                               // descriptor: LLoadableDescriptorsAttributeTest$V2; at 0x066D
+      }
+    }                                      // end of LoadableDescriptors
+  }                                        // end of Attributes
+}                                          // end of class LoadableDescriptorsAttributeTest$X

--- a/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.g.t.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.g.t.jasm
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+final class #2 /* LoadableDescriptorsAttributeTest$X */ version 69:65535
+{
+  const #1   = Fieldref    #2.#3;               // LoadableDescriptorsAttributeTest$X.v1:"[LLoadableDescriptorsAttributeTest$V1;"
+  const #2   = Class       #4;                  // LoadableDescriptorsAttributeTest$X
+  const #3   = NameAndType #5:#6;               // v1:"[LLoadableDescriptorsAttributeTest$V1;"
+  const #4   = Utf8        "LoadableDescriptorsAttributeTest$X";
+  const #5   = Utf8        "v1";
+  const #6   = Utf8        "[LLoadableDescriptorsAttributeTest$V1;";
+  const #7   = Fieldref    #2.#8;               // LoadableDescriptorsAttributeTest$X.v7:"LLoadableDescriptorsAttributeTest$V7;"
+  const #8   = NameAndType #9:#10;              // v7:"LLoadableDescriptorsAttributeTest$V7;"
+  const #9   = Utf8        "v7";
+  const #10  = Utf8        "LLoadableDescriptorsAttributeTest$V7;";
+  const #11  = Fieldref    #2.#12;              // LoadableDescriptorsAttributeTest$X.v10:"LLoadableDescriptorsAttributeTest$V10;"
+  const #12  = NameAndType #13:#14;             // v10:"LLoadableDescriptorsAttributeTest$V10;"
+  const #13  = Utf8        "v10";
+  const #14  = Utf8        "LLoadableDescriptorsAttributeTest$V10;";
+  const #15  = Methodref   #16.#17;             // java/lang/Object."<init>":"()V"
+  const #16  = Class       #18;                 // java/lang/Object
+  const #17  = NameAndType #19:#20;             // "<init>":"()V"
+  const #18  = Utf8        "java/lang/Object";
+  const #19  = Utf8        "<init>";
+  const #20  = Utf8        "()V";
+  const #21  = Utf8        "Code";
+  const #22  = Utf8        "LineNumberTable";
+  const #23  = Utf8        "foo";
+  const #24  = Utf8        "()LLoadableDescriptorsAttributeTest$V2;";
+  const #25  = Utf8        "(LLoadableDescriptorsAttributeTest$V3;)V";
+  const #26  = Utf8        "(I)V";
+  const #27  = Utf8        "goo";
+  const #28  = Utf8        "([LLoadableDescriptorsAttributeTest$V6;)V";
+  const #29  = Utf8        "StackMapTable";
+  const #30  = Class       #31;                 // LoadableDescriptorsAttributeTest$V5
+  const #31  = Utf8        "LoadableDescriptorsAttributeTest$V5";
+  const #32  = Utf8        "([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;";
+  const #33  = Utf8        "SourceFile";
+  const #34  = Utf8        "LoadableDescriptorsAttributeTest.java";
+  const #35  = Utf8        "NestHost";
+  const #36  = Class       #37;                 // LoadableDescriptorsAttributeTest
+  const #37  = Utf8        "LoadableDescriptorsAttributeTest";
+  const #38  = Utf8        "InnerClasses";
+  const #39  = Utf8        "X";
+  const #40  = Class       #41;                 // LoadableDescriptorsAttributeTest$V1
+  const #41  = Utf8        "LoadableDescriptorsAttributeTest$V1";
+  const #42  = Utf8        "V1";
+  const #43  = Class       #44;                 // LoadableDescriptorsAttributeTest$V7
+  const #44  = Utf8        "LoadableDescriptorsAttributeTest$V7";
+  const #45  = Utf8        "V7";
+  const #46  = Class       #47;                 // LoadableDescriptorsAttributeTest$V10
+  const #47  = Utf8        "LoadableDescriptorsAttributeTest$V10";
+  const #48  = Utf8        "V10";
+  const #49  = Class       #50;                 // LoadableDescriptorsAttributeTest$V2
+  const #50  = Utf8        "LoadableDescriptorsAttributeTest$V2";
+  const #51  = Utf8        "V2";
+  const #52  = Class       #53;                 // LoadableDescriptorsAttributeTest$V3
+  const #53  = Utf8        "LoadableDescriptorsAttributeTest$V3";
+  const #54  = Utf8        "V3";
+  const #55  = Class       #56;                 // LoadableDescriptorsAttributeTest$V6
+  const #56  = Utf8        "LoadableDescriptorsAttributeTest$V6";
+  const #57  = Utf8        "V6";
+  const #58  = Utf8        "V5";
+  const #59  = Class       #60;                 // LoadableDescriptorsAttributeTest$V9
+  const #60  = Utf8        "LoadableDescriptorsAttributeTest$V9";
+  const #61  = Utf8        "V9";
+  const #62  = Class       #63;                 // LoadableDescriptorsAttributeTest$V8
+  const #63  = Utf8        "LoadableDescriptorsAttributeTest$V8";
+  const #64  = Utf8        "V8";
+  const #65  = Utf8        "LoadableDescriptors";
+  const #66  = Utf8        "LLoadableDescriptorsAttributeTest$V3;";
+  const #67  = Utf8        "LLoadableDescriptorsAttributeTest$V2;";
+
+  final strict Field #5:#6;                     // v1:"[LLoadableDescriptorsAttributeTest$V1;"
+  final strict Field #9:#10;                    // v7:"LLoadableDescriptorsAttributeTest$V7;"
+  final strict Field #13:#14;                   // v10:"LLoadableDescriptorsAttributeTest$V10;"
+
+  Method       #19:#20                          // "<init>":"()V"
+    stack 2  locals 1
+  {
+     0:    aload_0;
+     1:    aconst_null;
+     2:    putfield          #1;                // Field v1:"[LLoadableDescriptorsAttributeTest$V1;"
+     5:    aload_0;
+     6:    aconst_null;
+     7:    putfield          #7;                // Field v7:"LLoadableDescriptorsAttributeTest$V7;"
+    10:    aload_0;
+    11:    aconst_null;
+    12:    putfield          #11;               // Field v10:"LLoadableDescriptorsAttributeTest$V10;"
+    15:    aload_0;
+    16:    invokespecial     #15;               // Method java/lang/Object."<init>":"()V"
+    19:    return;
+  }
+
+  Method       #23:#24                          // foo:"()LLoadableDescriptorsAttributeTest$V2;"
+    stack 1  locals 1
+  {
+     0:    aconst_null;
+     1:    areturn;
+  }
+
+  Method       #23:#25                          // foo:"(LLoadableDescriptorsAttributeTest$V3;)V"
+    stack 0  locals 2
+  {
+     0:    return;
+  }
+
+  Method       #23:#26                          // foo:"(I)V"
+    stack 1  locals 3
+  {
+     0:    aconst_null;
+     1:    astore_2;
+     2:    return;
+  }
+
+  Method       #27:#28                          // goo:"([LLoadableDescriptorsAttributeTest$V6;)V"
+    stack 1  locals 4
+  {
+     0:    aconst_null;
+     1:    astore_2;
+     2:    aload_2;
+     3:    ifnonnull         9;
+     6:    goto              11;
+     9:    aconst_null;
+    10:    astore_3;
+    11:    return;
+    StackMapTable: number_of_entries = 2
+           frame_type = 252                     // append
+             offset_delta = 9
+               locals_map = [ #30; ]            // class LoadableDescriptorsAttributeTest$V5;
+           frame_type = 1                       // same
+  }
+
+  Method       #27:#32                          // goo:"([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;"
+    stack 1  locals 2
+  {
+     0:    aconst_null;
+     1:    areturn;
+  }
+
+  SourceFile                 #34;               // LoadableDescriptorsAttributeTest.java
+
+  NestHost                   #36;               // LoadableDescriptorsAttributeTest
+
+  InnerClasses {
+    static final #39 = #2 of #36;               // X = class LoadableDescriptorsAttributeTest$X of class LoadableDescriptorsAttributeTest
+    final #42 = #40 of #36;                     // V1 = class LoadableDescriptorsAttributeTest$V1 of class LoadableDescriptorsAttributeTest
+    final #45 = #43 of #36;                     // V7 = class LoadableDescriptorsAttributeTest$V7 of class LoadableDescriptorsAttributeTest
+    abstract #48 = #46 of #36;                  // V10 = class LoadableDescriptorsAttributeTest$V10 of class LoadableDescriptorsAttributeTest
+    final #51 = #49 of #36;                     // V2 = class LoadableDescriptorsAttributeTest$V2 of class LoadableDescriptorsAttributeTest
+    final #54 = #52 of #36;                     // V3 = class LoadableDescriptorsAttributeTest$V3 of class LoadableDescriptorsAttributeTest
+    final #57 = #55 of #36;                     // V6 = class LoadableDescriptorsAttributeTest$V6 of class LoadableDescriptorsAttributeTest
+    final #58 = #30 of #36;                     // V5 = class LoadableDescriptorsAttributeTest$V5 of class LoadableDescriptorsAttributeTest
+    final #61 = #59 of #36;                     // V9 = class LoadableDescriptorsAttributeTest$V9 of class LoadableDescriptorsAttributeTest
+    final #64 = #62 of #36;                     // V8 = class LoadableDescriptorsAttributeTest$V8 of class LoadableDescriptorsAttributeTest
+  }
+
+  LoadableDescriptors        #66, #10, #67;     // "LLoadableDescriptorsAttributeTest$V3;", "LLoadableDescriptorsAttributeTest$V7;", "LLoadableDescriptorsAttributeTest$V2;"
+} // end Class LoadableDescriptorsAttributeTest$X compiled from "LoadableDescriptorsAttributeTest.java"

--- a/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.jasm
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+final class LoadableDescriptorsAttributeTest$X version 69:65535
+{
+  final strict Field v1:"[LLoadableDescriptorsAttributeTest$V1;";
+  final strict Field v7:"LLoadableDescriptorsAttributeTest$V7;";
+  final strict Field v10:"LLoadableDescriptorsAttributeTest$V10;";
+
+  Method       "<init>":"()V"
+    stack 2  locals 1
+  {
+         aload_0;
+         aconst_null;
+         putfield          Field v1:"[LLoadableDescriptorsAttributeTest$V1;";
+         aload_0;
+         aconst_null;
+         putfield          Field v7:"LLoadableDescriptorsAttributeTest$V7;";
+         aload_0;
+         aconst_null;
+         putfield          Field v10:"LLoadableDescriptorsAttributeTest$V10;";
+         aload_0;
+         invokespecial     Method java/lang/Object."<init>":"()V";
+         return;
+  }
+
+  Method       foo:"()LLoadableDescriptorsAttributeTest$V2;"
+    stack 1  locals 1
+  {
+         aconst_null;
+         areturn;
+  }
+
+  Method       foo:"(LLoadableDescriptorsAttributeTest$V3;)V"
+    stack 0  locals 2
+  {
+         return;
+  }
+
+  Method       foo:"(I)V"
+    stack 1  locals 3
+  {
+         aconst_null;
+         astore_2;
+         return;
+  }
+
+  Method       goo:"([LLoadableDescriptorsAttributeTest$V6;)V"
+    stack 1  locals 4
+  {
+         aconst_null;
+         astore_2;
+         aload_2;
+         ifnonnull         L9;
+         goto              L11;
+  L9:    stack_frame_type  append;
+           locals_map      class LoadableDescriptorsAttributeTest$V5;
+         aconst_null;
+         astore_3;
+  L11:   stack_frame_type  same;
+         return;
+  }
+
+  Method       goo:"([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;"
+    stack 1  locals 2
+  {
+         aconst_null;
+         areturn;
+  }
+
+  SourceFile               "LoadableDescriptorsAttributeTest.java";
+
+  NestHost                 "LoadableDescriptorsAttributeTest";
+
+  InnerClass               static final X = class LoadableDescriptorsAttributeTest$X of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V1 = class LoadableDescriptorsAttributeTest$V1 of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V7 = class LoadableDescriptorsAttributeTest$V7 of class LoadableDescriptorsAttributeTest;
+  InnerClass               abstract V10 = class LoadableDescriptorsAttributeTest$V10 of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V2 = class LoadableDescriptorsAttributeTest$V2 of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V3 = class LoadableDescriptorsAttributeTest$V3 of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V6 = class LoadableDescriptorsAttributeTest$V6 of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V5 = class LoadableDescriptorsAttributeTest$V5 of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V9 = class LoadableDescriptorsAttributeTest$V9 of class LoadableDescriptorsAttributeTest;
+  InnerClass               final V8 = class LoadableDescriptorsAttributeTest$V8 of class LoadableDescriptorsAttributeTest;
+
+  LoadableDescriptors      "LLoadableDescriptorsAttributeTest$V3;",
+                           "LLoadableDescriptorsAttributeTest$V7;",
+                           "LLoadableDescriptorsAttributeTest$V2;";
+} // end Class LoadableDescriptorsAttributeTest$X compiled from "LoadableDescriptorsAttributeTest.java"

--- a/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.jcod
+++ b/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/LoadableDescriptorsAttributeTest$X.jcod
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+class LoadableDescriptorsAttributeTest$X {
+  0xCAFEBABE;
+  65535;                                   // minor version
+  69;                                      // version
+  [] {                                     // Constant Pool
+    ;                                      // first element is empty
+    Field #2 #3;                           // #1
+    Class #4;                              // #2
+    NameAndType #5 #6;                     // #3
+    Utf8 "LoadableDescriptorsAttributeTest$X";  // #4
+    Utf8 "v1";                             // #5
+    Utf8 "[LLoadableDescriptorsAttributeTest$V1;";  // #6
+    Field #2 #8;                           // #7
+    NameAndType #9 #10;                    // #8
+    Utf8 "v7";                             // #9
+    Utf8 "LLoadableDescriptorsAttributeTest$V7;";  // #10
+    Field #2 #12;                          // #11
+    NameAndType #13 #14;                   // #12
+    Utf8 "v10";                            // #13
+    Utf8 "LLoadableDescriptorsAttributeTest$V10;";  // #14
+    Method #16 #17;                        // #15
+    Class #18;                             // #16
+    NameAndType #19 #20;                   // #17
+    Utf8 "java/lang/Object";               // #18
+    Utf8 "<init>";                         // #19
+    Utf8 "()V";                            // #20
+    Utf8 "Code";                           // #21
+    Utf8 "LineNumberTable";                // #22
+    Utf8 "foo";                            // #23
+    Utf8 "()LLoadableDescriptorsAttributeTest$V2;";  // #24
+    Utf8 "(LLoadableDescriptorsAttributeTest$V3;)V";  // #25
+    Utf8 "(I)V";                           // #26
+    Utf8 "goo";                            // #27
+    Utf8 "([LLoadableDescriptorsAttributeTest$V6;)V";  // #28
+    Utf8 "StackMapTable";                  // #29
+    Class #31;                             // #30
+    Utf8 "LoadableDescriptorsAttributeTest$V5";  // #31
+    Utf8 "([LLoadableDescriptorsAttributeTest$V9;)[LLoadableDescriptorsAttributeTest$V8;";  // #32
+    Utf8 "SourceFile";                     // #33
+    Utf8 "LoadableDescriptorsAttributeTest.java";  // #34
+    Utf8 "NestHost";                       // #35
+    Class #37;                             // #36
+    Utf8 "LoadableDescriptorsAttributeTest";  // #37
+    Utf8 "InnerClasses";                   // #38
+    Utf8 "X";                              // #39
+    Class #41;                             // #40
+    Utf8 "LoadableDescriptorsAttributeTest$V1";  // #41
+    Utf8 "V1";                             // #42
+    Class #44;                             // #43
+    Utf8 "LoadableDescriptorsAttributeTest$V7";  // #44
+    Utf8 "V7";                             // #45
+    Class #47;                             // #46
+    Utf8 "LoadableDescriptorsAttributeTest$V10";  // #47
+    Utf8 "V10";                            // #48
+    Class #50;                             // #49
+    Utf8 "LoadableDescriptorsAttributeTest$V2";  // #50
+    Utf8 "V2";                             // #51
+    Class #53;                             // #52
+    Utf8 "LoadableDescriptorsAttributeTest$V3";  // #53
+    Utf8 "V3";                             // #54
+    Class #56;                             // #55
+    Utf8 "LoadableDescriptorsAttributeTest$V6";  // #56
+    Utf8 "V6";                             // #57
+    Utf8 "V5";                             // #58
+    Class #60;                             // #59
+    Utf8 "LoadableDescriptorsAttributeTest$V9";  // #60
+    Utf8 "V9";                             // #61
+    Class #63;                             // #62
+    Utf8 "LoadableDescriptorsAttributeTest$V8";  // #63
+    Utf8 "V8";                             // #64
+    Utf8 "LoadableDescriptors";            // #65
+    Utf8 "LLoadableDescriptorsAttributeTest$V3;";  // #66
+    Utf8 "LLoadableDescriptorsAttributeTest$V2;";  // #67
+  }
+
+  0x0010;                                  // access
+  #2;                                      // this_cpx
+  #16;                                     // super_cpx
+
+  [] {                                     // Interfaces
+  }                                        // end of Interfaces
+
+  [] {                                     // Fields
+    {                                      // field
+      0x0810;                              // access
+      #5;                                  // name_index
+      #6;                                  // descriptor_index
+      [] {                                 // Attributes
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // field
+      0x0810;                              // access
+      #9;                                  // name_index
+      #10;                                 // descriptor_index
+      [] {                                 // Attributes
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // field
+      0x0810;                              // access
+      #13;                                 // name_index
+      #14;                                 // descriptor_index
+      [] {                                 // Attributes
+      }                                    // end of Attributes
+    }
+  }                                        // end of Fields
+
+  [] {                                     // Methods
+    {                                      // method
+      0x0000;                              // access
+      #19;                                 // name_index
+      #20;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#21) {                        // Code
+          2;                               // max_stack
+          1;                               // max_locals
+          Bytes[]{
+            0x2A 0x01 0xB5 0x00 0x01 0x2A 0x01 0xB5 0x00 0x07 0x2A 0x01;
+            0xB5 0x00 0x0B 0x2A 0xB7 0x00 0x0F 0xB1;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#22) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0   50;
+                   5   67;
+                  10   71;
+                  15   49;
+                  19   71;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0000;                              // access
+      #23;                                 // name_index
+      #24;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#21) {                        // Code
+          1;                               // max_stack
+          1;                               // max_locals
+          Bytes[]{
+            0x01 0xB0;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#22) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0   52;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0000;                              // access
+      #23;                                 // name_index
+      #25;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#21) {                        // Code
+          0;                               // max_stack
+          2;                               // max_locals
+          Bytes[]{
+            0xB1;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#22) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0   55;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0000;                              // access
+      #23;                                 // name_index
+      #26;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#21) {                        // Code
+          1;                               // max_stack
+          3;                               // max_locals
+          Bytes[]{
+            0x01 0x4D 0xB1;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#22) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0   57;
+                   2   58;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0000;                              // access
+      #27;                                 // name_index
+      #28;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#21) {                        // Code
+          1;                               // max_stack
+          4;                               // max_locals
+          Bytes[]{
+            0x01 0x4D 0x2C 0xC7 0x00 0x06 0xA7 0x00 0x05 0x01 0x4E 0xB1;
+;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#22) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0   60;
+                   2   61;
+                   9   64;
+                  11   66;
+              }
+            }                              // end of LineNumberTable
+            ;
+            Attr(#29) {                    // StackMapTable
+              [] {                         //
+                252b, 9, []z{O,#30};       // append_frame 1
+                1b;                        // same_frame
+              }
+            }                              // end of StackMapTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+    ;
+    {                                      // method
+      0x0000;                              // access
+      #27;                                 // name_index
+      #32;                                 // descriptor_index
+      [] {                                 // Attributes
+        Attr(#21) {                        // Code
+          1;                               // max_stack
+          2;                               // max_locals
+          Bytes[]{
+            0x01 0xB0;
+          }
+          [] {                             // Traps
+          }                                // end of Traps
+          [] {                             // Attributes
+            Attr(#22) {                    // LineNumberTable
+              [] {                         // line_number_table
+                   0   69;
+              }
+            }                              // end of LineNumberTable
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+  }                                        // end of Methods
+
+  [] {                                     // Attributes
+    Attr(#33) {                            // SourceFile
+      #34;
+    }                                      // end of SourceFile
+    ;
+    Attr(#35) {                            // NestHost
+      #36;
+    }                                      // end of NestHost
+    ;
+    Attr(#38) {                            // InnerClasses
+      [] {                                 // classes
+           #2   #36   #39  24;
+          #40   #36   #42  16;
+          #43   #36   #45  16;
+          #46   #36   #48 1024;
+          #49   #36   #51  16;
+          #52   #36   #54  16;
+          #55   #36   #57  16;
+          #30   #36   #58  16;
+          #59   #36   #61  16;
+          #62   #36   #64  16;
+      }
+    }                                      // end of InnerClasses
+    ;
+    Attr(#65) {                            // LoadableDescriptors
+      [] {                                 // Utf8
+        #66;
+        #10;
+        #67;
+      }
+    }                                      // end of LoadableDescriptors
+  }                                        // end of Attributes
+}


### PR DESCRIPTION
[CODETOOLS-7903806](https://bugs.openjdk.org/browse/CODETOOLS-7903806): Enhance jasm/jdis to support value classes and objects

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Issue
 * [CODETOOLS-7903806](https://bugs.openjdk.org/browse/CODETOOLS-7903806): Enhance jasm/jdis to support value classes and objects (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools.git pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.org/asmtools.git pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/79.diff">https://git.openjdk.org/asmtools/pull/79.diff</a>

</details>
