### PR TITLE
CODETOOLS-7902696: jdis does't catch circular references in bsm args

### DIFF
--- a/src/org/openjdk/asmtools/common/outputs/ByteOutput.java
+++ b/src/org/openjdk/asmtools/common/outputs/ByteOutput.java
@@ -60,12 +60,15 @@ public class ByteOutput extends NamedToolOutput {
 
     @Override
     public void finishClass(String fullyQualifiedName) throws IOException {
-        if (!getCurrentClassName().equals(fullyQualifiedName)) {
+        String fqn = getCurrentClassName();
+        if ( fqn != null && !fqn.equals(fullyQualifiedName)) {
             throw new RuntimeException("Ended different class: %s then was started %s".
-                    formatted(fullyQualifiedName, super.fullyQualifiedName));
+                    formatted(fullyQualifiedName, fqn));
         }
-        outputs.add(new NamedBinary(fullyQualifiedName, currentClass.toByteArray()));
-        super.fullyQualifiedName = null;
+        if (currentClass != null) {
+            outputs.add(new NamedBinary(fullyQualifiedName, currentClass.toByteArray()));
+        }
+        super.finishClass(fullyQualifiedName);
         currentClass = null;
 
     }

--- a/src/org/openjdk/asmtools/common/outputs/NamedToolOutput.java
+++ b/src/org/openjdk/asmtools/common/outputs/NamedToolOutput.java
@@ -28,12 +28,12 @@ import java.io.IOException;
 import java.util.Optional;
 
 /**
- * Historically, the output loggers for compilers had two stderrs, one to sdout and secon to stderr.
- * That should be removed, in favour of just dualstream tool output, printing output to stdout and log into stderr
+ * Historically, the output loggers for compilers had two stderrs, one to stdout and second to stderr.
+ * That should be removed, in favour of just dual stream tool output, printing output to stdout and log into stderr
  */
 public abstract class NamedToolOutput implements ToolOutput {
 
-    protected String fullyQualifiedName;
+    protected String fullyQualifiedName = "";
     /**
      * If the output is a file, then the destinationFileName is used to form the filename of the output.
      * 1. File FILENAME or class file CLASSNAME takes the highest priority. This filename cannot be overridden.
@@ -54,10 +54,6 @@ public abstract class NamedToolOutput implements ToolOutput {
         return fullyQualifiedName;
     }
 
-    public String getFullyQualifiedName() {
-        return fullyQualifiedName;
-    }
-
     @Override
     public void startClass(String fullyQualifiedName, Optional<String> suffix, Environment logger) throws IOException {
         this.fullyQualifiedName = fullyQualifiedName;
@@ -67,8 +63,8 @@ public abstract class NamedToolOutput implements ToolOutput {
 
     @Override
     public void finishClass(String fullyQualifiedName) throws IOException {
-        this.fullyQualifiedName = null;
         this.destinationFileName = null;
+        this.fullyQualifiedName = null;
     }
 
     public String getDestinationFileName() {

--- a/src/org/openjdk/asmtools/common/outputs/TextOutput.java
+++ b/src/org/openjdk/asmtools/common/outputs/TextOutput.java
@@ -48,7 +48,8 @@ public class TextOutput extends NamedToolOutput {
 
     @Override
     public String toString() {
-        return outputs.stream().map(a -> a.toString()).collect(Collectors.joining(System.lineSeparator()));
+        return outputs.stream().map(a -> a.toString()).
+                collect(Collectors.joining(System.lineSeparator()));
     }
 
     @Override
@@ -64,11 +65,15 @@ public class TextOutput extends NamedToolOutput {
 
     @Override
     public void finishClass(String fullyQualifiedName) throws IOException {
-        if (!getCurrentClassName().equals(fullyQualifiedName)) {
-            throw new RuntimeException("Ended different class - " + fullyQualifiedName + " - then started - " + super.fullyQualifiedName);
+        String fqn = getCurrentClassName();
+        if (fqn != null && !fqn.equals(fullyQualifiedName)) {
+            throw new RuntimeException("Ended different class: %s then was started %s".
+                    formatted(fullyQualifiedName, fqn));
         }
-        outputs.add(new NamedSource(fullyQualifiedName, curClsStringBuilder.toString(), namedSourceOrnament));
-        super.fullyQualifiedName = null;
+        if (curClsStringBuilder != null) {
+            outputs.add(new NamedSource(fullyQualifiedName, curClsStringBuilder.toString(), namedSourceOrnament));
+        }
+        super.finishClass(fullyQualifiedName);
         curClsStringBuilder = null;
     }
 
@@ -106,14 +111,14 @@ public class TextOutput extends NamedToolOutput {
         private BiFunction<String, String, String> ornament = (fname, body) ->
                 format(
                         """
-                        /**
-                        %s
-                        **/
-                        %s
-                        /**
-                        %s
-                        **/        
-                        """, fname, body, fname);
+                                /**
+                                %s
+                                **/
+                                %s
+                                /**
+                                %s
+                                **/        
+                                """, fname, body, fname);
         private final String fullyQualifiedName;
         private final String body;
 

--- a/src/org/openjdk/asmtools/jdis/ClassData.java
+++ b/src/org/openjdk/asmtools/jdis/ClassData.java
@@ -413,6 +413,11 @@ public class ClassData extends MemberData<ClassData> {
             } catch (Exception ignored) {
             }
         }
+        try {
+            environment.getToolOutput().finishClass(className);
+        } catch (IOException ignored) {
+        }
+        environment.getOutputs().flush();
     }
 
     /**

--- a/test/java/org/openjdk/asmtools/jasm/case7902696/JasmTests.java
+++ b/test/java/org/openjdk/asmtools/jasm/case7902696/JasmTests.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.asmtools.jasm.case7902696;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openjdk.asmtools.lib.action.EToolArguments;
+import org.openjdk.asmtools.lib.action.Jasm;
+import org.openjdk.asmtools.lib.action.Jdec;
+import org.openjdk.asmtools.lib.action.Jdis;
+import org.openjdk.asmtools.lib.log.LogAndBinResults;
+import org.openjdk.asmtools.lib.log.LogAndTextResults;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static java.lang.String.format;
+import static org.openjdk.asmtools.common.Environment.FAILED;
+import static org.openjdk.asmtools.common.Environment.OK;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class JasmTests {
+
+    private final Jasm jasm = new Jasm();
+
+    private File resourceDir;
+
+    private static Stream<Arguments> getJasmParameters() {
+        return Stream.of(
+                Arguments.of("CondyNestedResolution.g.jasm"),
+                Arguments.of("CondyNestedResolution.g.t.jasm"));
+    }
+
+    @BeforeAll
+    public void init() throws IOException {
+        resourceDir = new File(Objects.requireNonNull(this.getClass().
+                getResource("CondyNestedResolution.g.jasm")).getFile()).getParentFile();
+    }
+
+    /**
+     * This is the test for the issue: CODETOOLS-7902696 (https://bugs.openjdk.org/browse/CODETOOLS-7902696)
+     * "jdis doesn't catch circular references in bsm args"
+     * <p>
+     * public static Method bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;
+     * Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+     * stack 19 locals 19
+     * {
+     * getstatic Field java/lang/System.out:"Ljava/io/PrintStream;";
+     * ldc String "In bsm4arg";
+     * invokevirtual Method java/io/PrintStream.println:"(Ljava/lang/Object;)V";
+     * getstatic Field java/lang/System.out:"Ljava/io/PrintStream;";
+     * aload_3;
+     * invokevirtual Method java/io/PrintStream.println:"(Ljava/lang/Object;)V";
+     * getstatic Field java/lang/System.out:"Ljava/io/PrintStream;";
+     * aload 4;
+     * invokevirtual Method java/io/PrintStream.println:"(Ljava/lang/Object;)V";
+     * getstatic Field java/lang/System.out:"Ljava/io/PrintStream;";
+     * aload 5;
+     * invokevirtual Method java/io/PrintStream.println:"(Ljava/lang/Object;)V";
+     * getstatic Field java/lang/System.out:"Ljava/io/PrintStream;";
+     * aload 6;
+     * invokevirtual Method java/io/PrintStream.println:"(Ljava/lang/Object;)V";
+     * aload_3;
+     * areturn;
+     * }
+     * public static Method test_condy:"()V"
+     * stack 12 locals 12
+     * {
+     * jdis: fatal error in file: CondyNestedResolution.class
+     */
+    @ParameterizedTest
+    @MethodSource("getJasmParameters")
+    public void testJCoderWarning(String resourceName) {
+        // jasm to class
+        final LogAndBinResults binResult = jasm.compile(List.of(resourceDir + File.separator + resourceName));
+        Assertions.assertEquals(OK, binResult.result);
+       // class to jasm
+        LogAndTextResults textResult = new Jdis().setArgs(EToolArguments.JDIS).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(FAILED, textResult.result);
+        List<String> out = textResult.getLogStringsByPrefix("ERROR:");
+        Assertions.assertEquals(9, out.size());
+        for (String line : out) {
+            Assertions.assertTrue(line.contains("circular reference to Dynamic #"));
+        }
+    }
+}

--- a/test/java/org/openjdk/asmtools/lib/helper/BruteForceHelper.java
+++ b/test/java/org/openjdk/asmtools/lib/helper/BruteForceHelper.java
@@ -44,6 +44,7 @@ public class BruteForceHelper {
         add("SourceDebugExtensionNegative03.class");
         add("LoadableDescriptorsAttributeTest$X.class");
         add("InvalidSourceDebugExtension.class");
+        add("CondyNestedResolution.class");
     }};
 
     public static final String FRESHLY_BUILT_ASMTOOLS = "target/classes";

--- a/test/resources/org/openjdk/asmtools/jasm/case7902696/CondyNestedResolution.g.jasm
+++ b/test/resources/org/openjdk/asmtools/jasm/case7902696/CondyNestedResolution.g.jasm
@@ -1,0 +1,432 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+class #84 /* CondyNestedResolution */ version 55:0
+{
+  const #1   = String       #22;                 // "In bsm2arg"
+  const #2   = String       #61;                 // "In bsm4arg"
+  const #3   = String       #11;                 // "In bsm1arg"
+  const #4   = Dynamic      8:#12;               // #8:name:"Ljava/lang/String;"
+  const #5   = Method       #51.#10;             // java/lang/Object."<init>":"()V"
+  const #6   = Method       #13.#39;             // java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+  const #7   = Field        #50.#81;             // java/lang/System.out:"Ljava/io/PrintStream;"
+  const #8   = Method       #84.#45;             // CondyNestedResolution.test_condy:"()V"
+  const #9   = Utf8         "java/io/PrintStream";
+  const #10  = NameAndType  #71:#47;             // "<init>":"()V"
+  const #11  = Utf8         "In bsm1arg";
+  const #12  = NameAndType  #18:#17;             // name:"Ljava/lang/String;"
+  const #13  = class        #9;                  // java/io/PrintStream
+  const #14  = Utf8         "SourceFile";
+  const #15  = Utf8         "bsm3arg";
+  const #16  = Utf8         "CondyNestedResolution.jasm";
+  const #17  = Utf8         "Ljava/lang/String;";
+  const #18  = Utf8         "name";
+  const #19  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #20  = Utf8         "test_condy";
+  const #21  = NameAndType  #15:#19;             // bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #22  = Utf8         "In bsm2arg";
+  const #23  = Utf8         "Code";
+  const #24  = Utf8         "([Ljava/lang/String;)V";
+  const #25  = Utf8         "bsm4arg";
+  const #26  = Utf8         "out";
+  const #27  = NameAndType  #69:#55;             // bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #28  = Utf8         "BootstrapMethods";
+  const #29  = MethodHandle 6:#44;               // REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #30  = Method       #84.#63;             // CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #31  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #32  = Method       #84.#27;             // CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #33  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #34  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #35  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #36  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #37  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #38  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #39  = NameAndType  #40:#41;             // println:"(Ljava/lang/Object;)V"
+  const #40  = Utf8         "println";
+  const #41  = Utf8         "(Ljava/lang/Object;)V";
+  const #42  = Utf8         "java/lang/Object";
+  const #43  = Utf8         "java/lang/System";
+  const #44  = Method       #84.#21;             // CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #45  = NameAndType  #20:#47;             // test_condy:"()V"
+  const #46  = MethodHandle 6:#82;               // REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #47  = Utf8         "()V";
+  const #48  = String       #62;                 // "hello6"
+  const #49  = String       #64;                 // "hello5"
+  const #50  = class        #43;                 // java/lang/System
+  const #51  = class        #42;                 // java/lang/Object
+  const #52  = String       #65;                 // "hello4"
+  const #53  = String       #66;                 // "hello3"
+  const #54  = String       #67;                 // "hello2"
+  const #55  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #56  = Utf8         "main";
+  const #57  = String       #68;                 // "hello1"
+  const #58  = MethodHandle 6:#32;               // REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #59  = Utf8         "bsm1arg";
+  const #60  = NameAndType  #25:#83;             // bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #61  = Utf8         "In bsm4arg";
+  const #62  = Utf8         "hello6";
+  const #63  = NameAndType  #59:#31;             // bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #64  = Utf8         "hello5";
+  const #65  = Utf8         "hello4";
+  const #66  = Utf8         "hello3";
+  const #67  = Utf8         "hello2";
+  const #68  = Utf8         "hello1";
+  const #69  = Utf8         "bsm2arg";
+  const #70  = Utf8         "Ljava/io/PrintStream;";
+  const #71  = Utf8         "<init>";
+  const #72  = Utf8         "CondyNestedResolution";
+  const #73  = Dynamic      7:#12;               // #7:name:"Ljava/lang/String;"
+  const #74  = Dynamic      6:#12;               // #6:name:"Ljava/lang/String;"
+  const #75  = Dynamic      5:#12;               // #5:name:"Ljava/lang/String;"
+  const #76  = Dynamic      4:#12;               // #4:name:"Ljava/lang/String;"
+  const #77  = Dynamic      3:#12;               // #3:name:"Ljava/lang/String;"
+  const #78  = Dynamic      0:#12;               // #0:name:"Ljava/lang/String;"
+  const #79  = Dynamic      1:#12;               // #1:name:"Ljava/lang/String;"
+  const #80  = Dynamic      2:#12;               // #2:name:"Ljava/lang/String;"
+  const #81  = NameAndType  #26:#70;             // out:"Ljava/io/PrintStream;"
+  const #82  = Method       #84.#60;             // CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #83  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #84  = class        #72;                 // CondyNestedResolution
+
+  public Method #71:#47                          // "<init>":"()V"
+    stack 1  locals 1
+  {
+     0:    aload_0;
+     1:    invokespecial     #5;                 // Method java/lang/Object."<init>":"()V"
+     4:    return;
+  }
+
+  public static Method #59:#31                   // bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 4  locals 4
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #3;                 // String "In bsm1arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    aload_3;
+    16:    areturn;
+  }
+
+  public static Method #69:#55                   // bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 8  locals 8
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #1;                 // String "In bsm2arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    18:    aload             4;
+    20:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    23:    aload_3;
+    24:    areturn;
+  }
+
+  public static Method #15:#19                   // bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 19  locals 19
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #2;                 // String "In bsm4arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    18:    aload             4;
+    20:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    23:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    26:    aload             5;
+    28:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    31:    aload_3;
+    32:    areturn;
+  }
+
+  public static Method #25:#83                   // bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 19  locals 19
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #2;                 // String "In bsm4arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    18:    aload             4;
+    20:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    23:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    26:    aload             5;
+    28:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    31:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    34:    aload             6;
+    36:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    39:    aload_3;
+    40:    areturn;
+  }
+
+  public static Method #20:#47                   // test_condy:"()V"
+    stack 12  locals 12
+  {
+     0:    ldc               #4;                 // Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello1"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello2"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello4"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello6"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  0:#12;          <circular reference to Dynamic #78>,
+                                                 //         Dynamic  1:#12;          <circular reference to Dynamic #79>,
+                                                 //         Dynamic  6:#12;          <circular reference to Dynamic #74>,
+                                                 //         Dynamic  7:#12;          <circular reference to Dynamic #73>
+                                                 //       }
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello5"
+                                                 //     }
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello3"
+                                                 //   }
+                                                 // }
+     2:    return;
+  }
+
+  public static Method #56:#24                   // main:"([Ljava/lang/String;)V"
+    stack 2  locals 2
+  {
+     0:    invokestatic      #8;                 // Method test_condy:"()V"
+     3:    return;
+  }
+
+  SourceFile                 #16;                // CondyNestedResolution.jasm
+
+  BootstrapMethod            #36;                // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #57             // String "hello1"
+                             }
+
+  BootstrapMethod            #37;                // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #54             // String "hello2"
+                             }
+
+  BootstrapMethod            #38;                // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #52             // String "hello4"
+                             }
+
+  BootstrapMethod            #35;                // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #48             // String "hello6"
+                             }
+
+  BootstrapMethod            #58;                // REF_invokeStatic:CondyNestedResolution.bsm2arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #77,            // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello6"
+                                                 // }
+                                 #4              // Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello1"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello2"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello4"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello6"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  0:#12;          <circular reference to Dynamic #78>,
+                                                 //         Dynamic  1:#12;          <circular reference to Dynamic #79>,
+                                                 //         Dynamic  6:#12;          <circular reference to Dynamic #74>,
+                                                 //         Dynamic  7:#12;          <circular reference to Dynamic #73>
+                                                 //       }
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello5"
+                                                 //     }
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello3"
+                                                 //   }
+                                                 // }
+                             }
+
+  BootstrapMethod            #34;                // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #49             // String "hello5"
+                             }
+
+  BootstrapMethod            #29;                // REF_invokeStatic:CondyNestedResolution.bsm3arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #80,            // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello4"
+                                                 // }
+                                 #76,            // Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello6"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello1"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello2"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello4"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  3:#12;          <circular reference to Dynamic #77>,
+                                                 //         Dynamic  8:#12;          <circular reference to Dynamic #4>
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello5"
+                                                 //       }
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello3"
+                                                 //     }
+                                                 //   }
+                                                 // }
+                                 #75             // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello5"
+                                                 // }
+                             }
+
+  BootstrapMethod            #33;                // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #53             // String "hello3"
+                             }
+
+  BootstrapMethod            #46;                // REF_invokeStatic:CondyNestedResolution.bsm4arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+                             {
+                                 #78,            // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello1"
+                                                 // }
+                                 #79,            // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello2"
+                                                 // }
+                                 #74,            // Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello4"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello6"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello1"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello2"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  2:#12;          <circular reference to Dynamic #80>,
+                                                 //         Dynamic  4:#12;          <circular reference to Dynamic #76>,
+                                                 //         Dynamic  5:#12;          <circular reference to Dynamic #75>
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello3"
+                                                 //       }
+                                                 //     }
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello5"
+                                                 //   }
+                                                 // }
+                                 #73             // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello3"
+                                                 // }
+                             }
+} // end Class CondyNestedResolution compiled from "CondyNestedResolution.jasm"

--- a/test/resources/org/openjdk/asmtools/jasm/case7902696/CondyNestedResolution.g.t.jasm
+++ b/test/resources/org/openjdk/asmtools/jasm/case7902696/CondyNestedResolution.g.t.jasm
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+class #84 /* CondyNestedResolution */ version 55:0
+{
+  const #1   = String       #22;                 // "In bsm2arg"
+  const #2   = String       #61;                 // "In bsm4arg"
+  const #3   = String       #11;                 // "In bsm1arg"
+  const #4   = Dynamic      8:#12;               // #8:name:"Ljava/lang/String;"
+  const #5   = Methodref    #51.#10;             // java/lang/Object."<init>":"()V"
+  const #6   = Methodref    #13.#39;             // java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+  const #7   = Fieldref     #50.#81;             // java/lang/System.out:"Ljava/io/PrintStream;"
+  const #8   = Methodref    #84.#45;             // CondyNestedResolution.test_condy:"()V"
+  const #9   = Utf8         "java/io/PrintStream";
+  const #10  = NameAndType  #71:#47;             // "<init>":"()V"
+  const #11  = Utf8         "In bsm1arg";
+  const #12  = NameAndType  #18:#17;             // name:"Ljava/lang/String;"
+  const #13  = Class        #9;                  // java/io/PrintStream
+  const #14  = Utf8         "SourceFile";
+  const #15  = Utf8         "bsm3arg";
+  const #16  = Utf8         "CondyNestedResolution.jasm";
+  const #17  = Utf8         "Ljava/lang/String;";
+  const #18  = Utf8         "name";
+  const #19  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #20  = Utf8         "test_condy";
+  const #21  = NameAndType  #15:#19;             // bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #22  = Utf8         "In bsm2arg";
+  const #23  = Utf8         "Code";
+  const #24  = Utf8         "([Ljava/lang/String;)V";
+  const #25  = Utf8         "bsm4arg";
+  const #26  = Utf8         "out";
+  const #27  = NameAndType  #69:#55;             // bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #28  = Utf8         "BootstrapMethods";
+  const #29  = MethodHandle 6:#44;               // REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #30  = Methodref    #84.#63;             // CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #31  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #32  = Methodref    #84.#27;             // CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #33  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #34  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #35  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #36  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #37  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #38  = MethodHandle 6:#30;               // REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #39  = NameAndType  #40:#41;             // println:"(Ljava/lang/Object;)V"
+  const #40  = Utf8         "println";
+  const #41  = Utf8         "(Ljava/lang/Object;)V";
+  const #42  = Utf8         "java/lang/Object";
+  const #43  = Utf8         "java/lang/System";
+  const #44  = Methodref    #84.#21;             // CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #45  = NameAndType  #20:#47;             // test_condy:"()V"
+  const #46  = MethodHandle 6:#82;               // REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #47  = Utf8         "()V";
+  const #48  = String       #62;                 // "hello6"
+  const #49  = String       #64;                 // "hello5"
+  const #50  = Class        #43;                 // java/lang/System
+  const #51  = Class        #42;                 // java/lang/Object
+  const #52  = String       #65;                 // "hello4"
+  const #53  = String       #66;                 // "hello3"
+  const #54  = String       #67;                 // "hello2"
+  const #55  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #56  = Utf8         "main";
+  const #57  = String       #68;                 // "hello1"
+  const #58  = MethodHandle 6:#32;               // REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #59  = Utf8         "bsm1arg";
+  const #60  = NameAndType  #25:#83;             // bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #61  = Utf8         "In bsm4arg";
+  const #62  = Utf8         "hello6";
+  const #63  = NameAndType  #59:#31;             // bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #64  = Utf8         "hello5";
+  const #65  = Utf8         "hello4";
+  const #66  = Utf8         "hello3";
+  const #67  = Utf8         "hello2";
+  const #68  = Utf8         "hello1";
+  const #69  = Utf8         "bsm2arg";
+  const #70  = Utf8         "Ljava/io/PrintStream;";
+  const #71  = Utf8         "<init>";
+  const #72  = Utf8         "CondyNestedResolution";
+  const #73  = Dynamic      7:#12;               // #7:name:"Ljava/lang/String;"
+  const #74  = Dynamic      6:#12;               // #6:name:"Ljava/lang/String;"
+  const #75  = Dynamic      5:#12;               // #5:name:"Ljava/lang/String;"
+  const #76  = Dynamic      4:#12;               // #4:name:"Ljava/lang/String;"
+  const #77  = Dynamic      3:#12;               // #3:name:"Ljava/lang/String;"
+  const #78  = Dynamic      0:#12;               // #0:name:"Ljava/lang/String;"
+  const #79  = Dynamic      1:#12;               // #1:name:"Ljava/lang/String;"
+  const #80  = Dynamic      2:#12;               // #2:name:"Ljava/lang/String;"
+  const #81  = NameAndType  #26:#70;             // out:"Ljava/io/PrintStream;"
+  const #82  = Methodref    #84.#60;             // CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+  const #83  = Utf8         "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+  const #84  = Class        #72;                 // CondyNestedResolution
+
+  public Method #71:#47                          // "<init>":"()V"
+    stack 1  locals 1
+  {
+     0:    aload_0;
+     1:    invokespecial     #5;                 // Method java/lang/Object."<init>":"()V"
+     4:    return;
+  }
+
+  public static Method #59:#31                   // bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 4  locals 4
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #3;                 // String "In bsm1arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    aload_3;
+    16:    areturn;
+  }
+
+  public static Method #69:#55                   // bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 8  locals 8
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #1;                 // String "In bsm2arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    18:    aload             4;
+    20:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    23:    aload_3;
+    24:    areturn;
+  }
+
+  public static Method #15:#19                   // bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 19  locals 19
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #2;                 // String "In bsm4arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    18:    aload             4;
+    20:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    23:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    26:    aload             5;
+    28:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    31:    aload_3;
+    32:    areturn;
+  }
+
+  public static Method #25:#83                   // bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;"
+    stack 19  locals 19
+  {
+     0:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+     3:    ldc               #2;                 // String "In bsm4arg"
+     5:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+     8:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    11:    aload_3;
+    12:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    15:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    18:    aload             4;
+    20:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    23:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    26:    aload             5;
+    28:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    31:    getstatic         #7;                 // Field java/lang/System.out:"Ljava/io/PrintStream;"
+    34:    aload             6;
+    36:    invokevirtual     #6;                 // Method java/io/PrintStream.println:"(Ljava/lang/Object;)V"
+    39:    aload_3;
+    40:    areturn;
+  }
+
+  public static Method #20:#47                   // test_condy:"()V"
+    stack 12  locals 12
+  {
+     0:    ldc               #4;                 // Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello1"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello2"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello4"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello6"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  0:#12;          <circular reference to Dynamic #78>,
+                                                 //         Dynamic  1:#12;          <circular reference to Dynamic #79>,
+                                                 //         Dynamic  6:#12;          <circular reference to Dynamic #74>,
+                                                 //         Dynamic  7:#12;          <circular reference to Dynamic #73>
+                                                 //       }
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello5"
+                                                 //     }
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:Method CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello3"
+                                                 //   }
+                                                 // }
+     2:    return;
+  }
+
+  public static Method #56:#24                   // main:"([Ljava/lang/String;)V"
+    stack 2  locals 2
+  {
+     0:    invokestatic      #8;                 // Method test_condy:"()V"
+     3:    return;
+  }
+
+  SourceFile                 #16;                // CondyNestedResolution.jasm
+
+  BootstrapMethods {
+     0:    #36;                                  // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #57;                                  // String "hello1"
+
+     1:    #37;                                  // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #54;                                  // String "hello2"
+
+     2:    #38;                                  // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #52;                                  // String "hello4"
+
+     3:    #35;                                  // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #48;                                  // String "hello6"
+
+     4:    #58;                                  // REF_invokeStatic:CondyNestedResolution.bsm2arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #77,                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello6"
+                                                 // }
+           #4;                                   // Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello1"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello2"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello4"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello6"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  0:#12;          <circular reference to Dynamic #78>,
+                                                 //         Dynamic  1:#12;          <circular reference to Dynamic #79>,
+                                                 //         Dynamic  6:#12;          <circular reference to Dynamic #74>,
+                                                 //         Dynamic  7:#12;          <circular reference to Dynamic #73>
+                                                 //       }
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello5"
+                                                 //     }
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello3"
+                                                 //   }
+                                                 // }
+
+     5:    #34;                                  // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #49;                                  // String "hello5"
+
+     6:    #29;                                  // REF_invokeStatic:CondyNestedResolution.bsm3arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #80,                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello4"
+                                                 // }
+           #76,                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello6"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello1"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello2"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello4"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  3:#12;          <circular reference to Dynamic #77>,
+                                                 //         Dynamic  8:#12;          <circular reference to Dynamic #4>
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello5"
+                                                 //       }
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello3"
+                                                 //     }
+                                                 //   }
+                                                 // }
+           #75;                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello5"
+                                                 // }
+
+     7:    #33;                                  // REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #53;                                  // String "hello3"
+
+     8:    #46;                                  // REF_invokeStatic:CondyNestedResolution.bsm4arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;";
+     Arguments:
+           #78,                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello1"
+                                                 // }
+           #79,                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello2"
+                                                 // }
+           #74,                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello4"
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm2arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       String "hello6"
+                                                 //     },
+                                                 //     Dynamic REF_invokeStatic:CondyNestedResolution.bsm4arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //     name:"Ljava/lang/String;" {
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello1"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello2"
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm3arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         Dynamic  2:#12;          <circular reference to Dynamic #80>,
+                                                 //         Dynamic  4:#12;          <circular reference to Dynamic #76>,
+                                                 //         Dynamic  5:#12;          <circular reference to Dynamic #75>
+                                                 //       },
+                                                 //       Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":name:"Ljava/lang/String;" {
+                                                 //         String "hello3"
+                                                 //       }
+                                                 //     }
+                                                 //   },
+                                                 //   Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 //   name:"Ljava/lang/String;" {
+                                                 //     String "hello5"
+                                                 //   }
+                                                 // }
+           #73;                                  // Dynamic REF_invokeStatic:CondyNestedResolution.bsm1arg:
+                                                 // "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;":
+                                                 // name:"Ljava/lang/String;" {
+                                                 //   String "hello3"
+                                                 // }
+  }
+} // end Class CondyNestedResolution compiled from "CondyNestedResolution.jasm"


### PR DESCRIPTION
[CODETOOLS-7902696](https://bugs.openjdk.org/browse/CODETOOLS-7902696): jdis does't catch circular references in bsm args