### PR TITLE
CODETOOLS-7904014: jasm: the jasm incorrectly parses the PermittedSubclasses/NestMembers attribute

### DIFF
--- a/src/org/openjdk/asmtools/jasm/ArrayAttr.java
+++ b/src/org/openjdk/asmtools/jasm/ArrayAttr.java
@@ -33,18 +33,18 @@ import java.util.List;
  * <p>
  * JEP 181 (Nest-based Access Control): class file 55.0
  * NestMembers_attribute {
- * u2 attribute_name_index;
- * u4 attribute_length;
- * u2 number_of_classes;
- * u2 classes[number_of_classes];
+ *      u2 attribute_name_index;
+ *      u4 attribute_length;
+ *      u2 number_of_classes;
+ *      u2 classes[number_of_classes];
  * }
  * <p>
  * JEP 360 (Sealed types): class file 59.65535
  * PermittedSubclasses_attribute {
- * u2 attribute_name_index;
- * u4 attribute_length;
- * u2 number_of_classes;
- * u2 classes[number_of_classes];
+ *      u2 attribute_name_index;
+ *      u4 attribute_length;
+ *      u2 number_of_classes;
+ *      u2 classes[number_of_classes];
  * }
  * <p>
  * Valhalla:
@@ -62,7 +62,7 @@ public class ArrayAttr extends AttrData {
     public ArrayAttr(ConstantPool pool, EAttribute attribute, List<ConstCell> constCellList) {
         super(pool, attribute);
         for (ConstCell<?> cell : constCellList) {
-            this.cells.add(cell);
+            this.cells.add(classifyConstCell(pool, cell));
         }
     }
 

--- a/src/org/openjdk/asmtools/jasm/LoadableDescriptorsAttr.java
+++ b/src/org/openjdk/asmtools/jasm/LoadableDescriptorsAttr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,14 @@ import org.openjdk.asmtools.common.structure.EAttribute;
 
 import java.util.List;
 
-import static org.openjdk.asmtools.jasm.ClassFileConst.ConstType.CONSTANT_UTF8;
-
 /**
  * Valhalla:
  * <p>
  * LoadableDescriptors_attribute {
- * u2 attribute_name_index;
- * u4 attribute_length;
- * u2 number_of_descriptors;
- * u2 descriptors[number_of_descriptors];
+ *      u2 attribute_name_index;
+ *      u4 attribute_length;
+ *      u2 number_of_descriptors;
+ *      u2 descriptors[number_of_descriptors];
  * }
  */
 public class LoadableDescriptorsAttr extends ArrayAttr {
@@ -45,6 +43,6 @@ public class LoadableDescriptorsAttr extends ArrayAttr {
 
     @Override
     protected ConstCell<?> classifyConstCell(ConstantPool pool, ConstCell<?> cell) {
-        return pool.findCell(CONSTANT_UTF8, cell);
+        return cell;
     }
 }

--- a/src/org/openjdk/asmtools/jdis/AttributeData.java
+++ b/src/org/openjdk/asmtools/jdis/AttributeData.java
@@ -24,7 +24,6 @@ package org.openjdk.asmtools.jdis;
 
 import org.openjdk.asmtools.common.FormatError;
 import org.openjdk.asmtools.common.ToolLogger;
-import org.openjdk.asmtools.common.structure.EAttribute;
 import org.openjdk.asmtools.jasm.TableFormatModel;
 
 import java.io.DataInputStream;
@@ -70,10 +69,15 @@ public abstract class AttributeData<A extends AttributeData<A>> extends Indenter
         logger = classData.data.environment.getLogger();
         tableToken = token;
         switch (tableToken) {
-            case NEST_HOST, SOURCE_FILE -> {
+            case SOURCE_FILE -> {
                 attribute_length = 2;
                 idxStringSupplier = () -> "#%d;".formatted(cpx);
                 namePrinter = () -> println("\"%s\";".formatted(name != null ? name : "???"));
+            }
+            case NEST_HOST -> {
+                attribute_length = 2;
+                idxStringSupplier = () -> "#%d;".formatted(cpx);
+                namePrinter = () -> println("%s;".formatted(name != null ? name : "\"???\""));
             }
             case ENCLOSING_METHOD -> {
                 attribute_length = 4;

--- a/test/java/org/openjdk/asmtools/attribute/NestHost/NestHostTests.java
+++ b/test/java/org/openjdk/asmtools/attribute/NestHost/NestHostTests.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.asmtools.attribute.LoadableDescriptors;
+package org.openjdk.asmtools.attribute.NestHost;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,7 +48,7 @@ import static org.openjdk.asmtools.lib.utility.StringUtils.funcNormalizeText;
 import static org.openjdk.asmtools.lib.utility.StringUtils.funcSubStrCount;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoadableDescriptorsTests {
+public class NestHostTests {
 
     private Jasm jasm = new Jasm();
     private Jcoder jcoder = new Jcoder();
@@ -56,36 +56,43 @@ public class LoadableDescriptorsTests {
 
     private static Stream<Arguments> getJasmParameters() {
         return Stream.of(
-                Arguments.of("Test01.jasm", EToolArguments.JDIS_G_T, List.of(
+                Arguments.of("Test01.jasm", EToolArguments.JDIS_G, List.of(
                                 (Consumer<String>) (text) -> assertThat(text, allOf(
-                                                matchesPattern(".*const #\\d = Utf8 \"LLoadableDescriptors01;\";.*"),
-                                                matchesPattern(".*const #\\d = Utf8 \"LLoadableDescriptors02;\";.*"),
-                                                matchesPattern(".*LoadableDescriptors #\\d, #\\d; // \"LLoadableDescriptors01;\", \"LLoadableDescriptors02;\".*")
-                                        )
-                                ),
+                                        matchesPattern(".*const #\\d = class #\\d; // NestHost01.*"),
+                                        matchesPattern(".*NestHost #\\d; // org/openjdk/asmtools/attribute/NestHost/NestHost01.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(10, funcSubStrCount.apply(text, "LoadableDescriptors"))
+                                        Assertions.assertEquals(11, funcSubStrCount.apply(text, "NestHost"))
                         )
                 ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.jasm", EToolArguments.JDIS, List.of(
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
+                Arguments.of("Test01.jasm", EToolArguments.JDIS, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*NestHost org/openjdk/asmtools/attribute/NestHost/NestHost01;.*")
+                                ))
                         )
                 ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jasm", EToolArguments.JDIS_G_T, List.of(
+                Arguments.of("Test01.g.jasm", EToolArguments.JDIS_G_T, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*const #\\d = Class #\\d; // NestHost01.*"),
+                                        matchesPattern(".*NestHost #\\d; // org/openjdk/asmtools/attribute/NestHost/NestHost01.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
+                                        Assertions.assertEquals(11, funcSubStrCount.apply(text, "NestHost"))
                         )
                 ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.t.jasm", EToolArguments.JDIS_G, List.of(
+                Arguments.of("Test02.jasm", EToolArguments.JDIS_G, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*const #\\d = class #\\d; // NestHost02.*"),
+                                        matchesPattern(".*NestHost #\\d; // org/openjdk/asmtools/attribute/NestHost/NestHost02.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
+                                        Assertions.assertEquals(11, funcSubStrCount.apply(text, "NestHost"))
+                        )
+                ),
+                Arguments.of("Test02.jasm", EToolArguments.JDIS, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*NestHost org/openjdk/asmtools/attribute/NestHost/NestHost02;.*")
+                                ))
                         )
                 )
         );
@@ -93,20 +100,13 @@ public class LoadableDescriptorsTests {
 
     private static Stream<Arguments> getJcodParameters() {
         return Stream.of(
-                Arguments.of("LoadableDescriptorsAttributeTest$X.jcod", EToolArguments.JDEC_G, List.of(
-                        (Consumer<String>) (text) -> assertThat(text, allOf(
-                                        matchesPattern(".*Attr\\(#\\d\\d, \\d\\) \\{ // LoadableDescriptors at.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V3.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V7.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V2.*")
-                                )
-                        ))
-                ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jcod", EToolArguments.JDEC, List.of(
+                Arguments.of("Test01.jcod", EToolArguments.JDEC_G, List.of(
                                 (Consumer<String>) (text) -> assertThat(text, allOf(
-                                        matchesPattern(".*Attr\\(#\\d\\d\\) \\{ // LoadableDescriptors.*"))),
+                                        matchesPattern(".*#\\d; // class: org/openjdk/asmtools/attribute/NestHost/NestHost01.*"),
+                                        matchesPattern(".*Attr.#\\d, 2. \\{ // NestHost.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(26, funcSubStrCount.apply(text, "LoadableDescriptors"))
+                                        Assertions.assertEquals(11, funcSubStrCount.apply(text, "NestHost"))
                         )
                 )
         );

--- a/test/java/org/openjdk/asmtools/attribute/NestMembers/NestMembersTests.java
+++ b/test/java/org/openjdk/asmtools/attribute/NestMembers/NestMembersTests.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.asmtools.attribute.LoadableDescriptors;
+package org.openjdk.asmtools.attribute.NestMembers;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,7 +48,7 @@ import static org.openjdk.asmtools.lib.utility.StringUtils.funcNormalizeText;
 import static org.openjdk.asmtools.lib.utility.StringUtils.funcSubStrCount;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoadableDescriptorsTests {
+public class NestMembersTests {
 
     private Jasm jasm = new Jasm();
     private Jcoder jcoder = new Jcoder();
@@ -58,34 +58,27 @@ public class LoadableDescriptorsTests {
         return Stream.of(
                 Arguments.of("Test01.jasm", EToolArguments.JDIS_G_T, List.of(
                                 (Consumer<String>) (text) -> assertThat(text, allOf(
-                                                matchesPattern(".*const #\\d = Utf8 \"LLoadableDescriptors01;\";.*"),
-                                                matchesPattern(".*const #\\d = Utf8 \"LLoadableDescriptors02;\";.*"),
-                                                matchesPattern(".*LoadableDescriptors #\\d, #\\d; // \"LLoadableDescriptors01;\", \"LLoadableDescriptors02;\".*")
-                                        )
-                                ),
+                                        matchesPattern(".*const #\\d = Class #\\d; // NestMember01.*"),
+                                        matchesPattern(".*NestMembers #\\d; // NestMember01.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(10, funcSubStrCount.apply(text, "LoadableDescriptors"))
+                                        Assertions.assertEquals(6, funcSubStrCount.apply(text, "NestMembers"))
                         )
                 ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.jasm", EToolArguments.JDIS, List.of(
+                Arguments.of("Test01.g.t.jasm", EToolArguments.JDIS, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*NestMembers NestMember01.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
+                                        Assertions.assertEquals(6, funcSubStrCount.apply(text, "NestMember"))
                         )
                 ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jasm", EToolArguments.JDIS_G_T, List.of(
+                Arguments.of("Test02.jasm", EToolArguments.JDIS_G_T, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*NestMembers #\\d\\d, // Test02\\$ClassInsideRecord2.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
-                        )
-                ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.t.jasm", EToolArguments.JDIS_G, List.of(
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
+                                        Assertions.assertEquals(2, funcSubStrCount.apply(text, "NestMembers"))
                         )
                 )
         );
@@ -93,20 +86,13 @@ public class LoadableDescriptorsTests {
 
     private static Stream<Arguments> getJcodParameters() {
         return Stream.of(
-                Arguments.of("LoadableDescriptorsAttributeTest$X.jcod", EToolArguments.JDEC_G, List.of(
-                        (Consumer<String>) (text) -> assertThat(text, allOf(
-                                        matchesPattern(".*Attr\\(#\\d\\d, \\d\\) \\{ // LoadableDescriptors at.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V3.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V7.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V2.*")
-                                )
-                        ))
-                ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jcod", EToolArguments.JDEC, List.of(
+                Arguments.of("Test01.jcod", EToolArguments.JDEC_G, List.of(
                                 (Consumer<String>) (text) -> assertThat(text, allOf(
-                                        matchesPattern(".*Attr\\(#\\d\\d\\) \\{ // LoadableDescriptors.*"))),
+                                        matchesPattern(".*#\\d; // class: org/openjdk/asmtools/attribute/NestMembers/Test01/NestMember01 at.*"),
+                                        matchesPattern(".*Attr.#\\d, 4. \\{ // NestMembers.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(26, funcSubStrCount.apply(text, "LoadableDescriptors"))
+                                        Assertions.assertEquals(8, funcSubStrCount.apply(text, "NestMembers"))
                         )
                 )
         );
@@ -114,8 +100,7 @@ public class LoadableDescriptorsTests {
 
     @BeforeAll
     public void init() throws IOException {
-        resourceDir = new File(Objects.requireNonNull(this.getClass().
-                getResource("Test01.jasm")).getFile()).getParentFile();
+        resourceDir = new File(Objects.requireNonNull(this.getClass().getResource("Test01.jasm")).getFile()).getParentFile();
     }
 
     @ParameterizedTest

--- a/test/java/org/openjdk/asmtools/attribute/PermittedSubclasses/PermittedSubclassesTests.java
+++ b/test/java/org/openjdk/asmtools/attribute/PermittedSubclasses/PermittedSubclassesTests.java
@@ -20,7 +20,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.openjdk.asmtools.attribute.LoadableDescriptors;
+package org.openjdk.asmtools.attribute.PermittedSubclasses;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -48,7 +48,7 @@ import static org.openjdk.asmtools.lib.utility.StringUtils.funcNormalizeText;
 import static org.openjdk.asmtools.lib.utility.StringUtils.funcSubStrCount;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class LoadableDescriptorsTests {
+public class PermittedSubclassesTests {
 
     private Jasm jasm = new Jasm();
     private Jcoder jcoder = new Jcoder();
@@ -58,34 +58,40 @@ public class LoadableDescriptorsTests {
         return Stream.of(
                 Arguments.of("Test01.jasm", EToolArguments.JDIS_G_T, List.of(
                                 (Consumer<String>) (text) -> assertThat(text, allOf(
-                                                matchesPattern(".*const #\\d = Utf8 \"LLoadableDescriptors01;\";.*"),
-                                                matchesPattern(".*const #\\d = Utf8 \"LLoadableDescriptors02;\";.*"),
-                                                matchesPattern(".*LoadableDescriptors #\\d, #\\d; // \"LLoadableDescriptors01;\", \"LLoadableDescriptors02;\".*")
-                                        )
-                                ),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // SubClass01.*"),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // SubClass02.*"),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // SubClass03.*"),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // SubClass04.*"),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // NestMember01.*"),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // NestMember02.*"),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // NestMember03.*"),
+                                        matchesPattern(".*const #\\d\\d = Class #\\d\\d; // NestMember04.*"),
+                                        matchesPattern(".*NestMembers #\\d\\d, // NestMember0\\d.*"),
+                                        matchesPattern(".*PermittedSubclasses #\\d\\d, // SubClass0\\d.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(10, funcSubStrCount.apply(text, "LoadableDescriptors"))
+                                        Assertions.assertEquals(2, funcSubStrCount.apply(text, "NestMembers")),
+                                (Consumer<String>) (text) ->
+                                        Assertions.assertEquals(5, funcSubStrCount.apply(text, "PermittedSubclasses"))
                         )
                 ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.jasm", EToolArguments.JDIS, List.of(
+                Arguments.of("Test01.g.t.jasm", EToolArguments.JDIS, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*NestMembers NestMember0\\d,.*"),
+                                        matchesPattern(".*PermittedSubclasses SubClass0\\d,.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
+                                        Assertions.assertEquals(12, funcSubStrCount.apply(text, "NestMember0")),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
+                                        Assertions.assertEquals(4, funcSubStrCount.apply(text, "SubClass0"))
                         )
                 ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jasm", EToolArguments.JDIS_G_T, List.of(
+                Arguments.of("Test02.jasm", EToolArguments.JDIS_G_T, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        matchesPattern(".*PermittedSubclasses #\\d\\d, // Test02\\$ClassInsideRecord2.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
-                        )
-                ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.t.jasm", EToolArguments.JDIS_G, List.of(
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "LoadableDescriptors ")),
-                                (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(3, funcSubStrCount.apply(text, "strict "))
+                                        Assertions.assertEquals(2, funcSubStrCount.apply(text, "PermittedSubclasses"))
                         )
                 )
         );
@@ -93,29 +99,20 @@ public class LoadableDescriptorsTests {
 
     private static Stream<Arguments> getJcodParameters() {
         return Stream.of(
-                Arguments.of("LoadableDescriptorsAttributeTest$X.jcod", EToolArguments.JDEC_G, List.of(
-                        (Consumer<String>) (text) -> assertThat(text, allOf(
-                                        matchesPattern(".*Attr\\(#\\d\\d, \\d\\) \\{ // LoadableDescriptors at.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V3.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V7.*"),
-                                        matchesPattern(".*descriptor: LLoadableDescriptorsAttributeTest\\$V2.*")
-                                )
-                        ))
-                ),
-                Arguments.of("LoadableDescriptorsAttributeTest$X.g.jcod", EToolArguments.JDEC, List.of(
+                Arguments.of("Test01.jcod", EToolArguments.JDEC_G, List.of(
                                 (Consumer<String>) (text) -> assertThat(text, allOf(
-                                        matchesPattern(".*Attr\\(#\\d\\d\\) \\{ // LoadableDescriptors.*"))),
+                                        matchesPattern(".*#\\d\\d; // subclass: org/openjdk/asmtools/attribute/PermittedSubclasses/atr/SubClass01 at.*"),
+                                        matchesPattern(".*Attr\\(#\\d\\d, \\d\\) \\{ // PermittedSubclasses at.*")
+                                )),
                                 (Consumer<String>) (text) ->
-                                        Assertions.assertEquals(26, funcSubStrCount.apply(text, "LoadableDescriptors"))
+                                        Assertions.assertEquals(8, funcSubStrCount.apply(text, "PermittedSubclasses"))
                         )
                 )
         );
     }
-
     @BeforeAll
     public void init() throws IOException {
-        resourceDir = new File(Objects.requireNonNull(this.getClass().
-                getResource("Test01.jasm")).getFile()).getParentFile();
+        resourceDir = new File(Objects.requireNonNull(this.getClass().getResource("Test01.jasm")).getFile()).getParentFile();
     }
 
     @ParameterizedTest

--- a/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/Test01.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/LoadableDescriptors/Test01.jasm
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package org/openjdk/asmtools/attribute/LoadableDescriptors;
+
+public class Test01 version 55:0
+{
+  LoadableDescriptors     "LLoadableDescriptors01;", "LLoadableDescriptors02;";
+
+  InnerClass               public Test01 = class Test01 of class OuterClass;
+} // end Class org/openjdk/asmtools/attribute/NestHost/Test01

--- a/test/resources/org/openjdk/asmtools/attribute/NestHost/Test01.g.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/NestHost/Test01.g.jasm
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package org/openjdk/asmtools/attribute/NestHost;
+
+public class #2 /* Test01 */ version 55:0
+{
+  const #1   = Utf8  "org/openjdk/asmtools/attribute/NestHost/Test01";
+  const #2   = Class #1;                  // Test01
+  const #3   = Utf8  "org/openjdk/asmtools/attribute/NestHost/NestHost01";
+  const #4   = Utf8  "NestHost";
+  const #5   = Class #3;                  // NestHost01
+  const #6   = Utf8  "Test01";
+  const #7   = Utf8  "org/openjdk/asmtools/attribute/NestHost/OuterClass";
+  const #8   = Class #7;                  // OuterClass
+  const #9   = Utf8  "InnerClasses";
+  const #10  = Utf8  "Test01.jasm";
+  const #11  = Utf8  "SourceFile";
+  const #12  = Utf8  "java/lang/Object";
+  const #13  = Class #12;                 // java/lang/Object
+
+  SourceFile                 #10;         // Test01.jasm
+
+  NestHost                   #5;          // org/openjdk/asmtools/attribute/NestHost/NestHost01
+
+  InnerClasses {
+    public #6 = #2 of #8;                 // Test01 = class Test01 of class OuterClass
+  }
+} // end Class org/openjdk/asmtools/attribute/NestHost/Test01 compiled from "Test01.jasm"

--- a/test/resources/org/openjdk/asmtools/attribute/NestHost/Test01.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/NestHost/Test01.jasm
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package org/openjdk/asmtools/attribute/NestHost;
+
+public class Test01 version 55:0
+{
+  NestHost                 "NestHost01";
+
+  InnerClass               public Test01 = class Test01 of class OuterClass;
+} // end Class org/openjdk/asmtools/attribute/NestHost/Test01

--- a/test/resources/org/openjdk/asmtools/attribute/NestHost/Test01.jcod
+++ b/test/resources/org/openjdk/asmtools/attribute/NestHost/Test01.jcod
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ */
+class org/openjdk/asmtools/attribute/NestHost/Test01 {
+  0xCAFEBABE;
+  0;                                       // minor version
+  55;                                      // version
+  [14] {                                   // Constant Pool
+    ;                                      // first element is empty
+    Utf8 "org/openjdk/asmtools/attribute/NestHost/Test01";  // #1     at 0x0A
+    Class #1;                              // #2     at 0x36
+    Utf8 "org/openjdk/asmtools/attribute/NestHost/NestHost01";  // #3     at 0x39
+    Utf8 "NestHost";                       // #4     at 0x69
+    Class #3;                              // #5     at 0x74
+    Utf8 "Test01";                         // #6     at 0x77
+    Utf8 "org/openjdk/asmtools/attribute/NestHost/OuterClass";  // #7     at 0x80
+    Class #7;                              // #8     at 0xB0
+    Utf8 "InnerClasses";                   // #9     at 0xB3
+    Utf8 "Test01.jasm";                    // #10     at 0xC2
+    Utf8 "SourceFile";                     // #11     at 0xD0
+    Utf8 "java/lang/Object";               // #12     at 0xDD
+    Class #12;                             // #13     at 0xF0
+  }                                        // end of Constant Pool
+
+  0x0001;                                  // access [ ACC_PUBLIC ]
+  #2;                                      // this_cpx
+  #13;                                     // super_cpx
+
+  [0] {                                    // Interfaces
+  }                                        // end of Interfaces
+
+  [0] {                                    // Fields
+  }                                        // end of Fields
+
+  [0] {                                    // Methods
+  }                                        // end of Methods
+
+  [3] {                                    // Attributes
+    Attr(#11, 2) {                         // SourceFile at 0x0101
+      #10;
+    }                                      // end of SourceFile
+    ;
+    Attr(#9, 10) {                         // InnerClasses at 0x0109
+      [1] {                                // classes
+           #2    #8    #6   1;             // access [ ACC_PUBLIC ]
+      }
+    }                                      // end of InnerClasses
+    ;
+    Attr(#4, 2) {                          // NestHost at 0x0119
+      #5;                                  // class: org/openjdk/asmtools/attribute/NestHost/NestHost01 at 0x0121
+    }                                      // end of NestHost
+  }                                        // end of Attributes
+}                                          // end of class org/openjdk/asmtools/attribute/NestHost/Test01

--- a/test/resources/org/openjdk/asmtools/attribute/NestHost/Test02.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/NestHost/Test02.jasm
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package org/openjdk/asmtools/attribute/NestHost;
+
+public class Test02 version 55:0
+{
+  SourceFile               "Test02.jasm";
+
+  NestHost                 org/openjdk/asmtools/attribute/NestHost/NestHost02;
+
+  InnerClass               public Test02 = class Test02 of class OuterClass;
+} // end Class org/openjdk/asmtools/attribute/NestHost/Test02 compiled from "Test02.jasm"

--- a/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test01.g.t.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test01.g.t.jasm
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+ package org/openjdk/asmtools/attribute/NestMembers/Test01;
+
+public class #2 /* Test01 */ version 55:0
+{
+  const #1   = Utf8  "org/openjdk/asmtools/attribute/NestMembers/Test01/Test01";
+  const #2   = Class #1;                  // Test01
+  const #3   = Utf8  "NestMember01";
+  const #4   = Utf8  "org/openjdk/asmtools/attribute/NestMembers/Test01/NestMember01";
+  const #5   = Class #4;                  // NestMember01
+  const #6   = Utf8  "InnerClasses";
+  const #7   = Utf8  "NestMembers";
+  const #8   = Utf8  "Test01.jasm";
+  const #9   = Utf8  "SourceFile";
+  const #10  = Utf8  "java/lang/Object";
+  const #11  = Class #10;                 // java/lang/Object
+
+  SourceFile                 #8;          // Test01.jasm
+
+  InnerClasses {
+    public #3 = #5 of #2;                 // NestMember01 = class NestMember01 of class Test01
+  }
+
+  NestMembers                #5;          // NestMember01
+} // end Class org/openjdk/asmtools/attribute/NestMembers/Test01/Test01 compiled from "Test01.jasm"

--- a/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test01.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test01.jasm
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package org/openjdk/asmtools/attribute/NestMembers/Test01;
+
+public class Test01 version 55:0
+{
+  InnerClass               public NestMember01 = class NestMember01 of class Test01;
+
+  NestMembers              NestMember01;
+} // end Class org/openjdk/asmtools/attribute/NestMembers/Test01

--- a/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test01.jcod
+++ b/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test01.jcod
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+class org/openjdk/asmtools/attribute/NestMembers/Test01 {
+  0xCAFEBABE;
+  0;                                       // minor version
+  55;                                      // version
+  [12] {                                   // Constant Pool
+    ;                                      // first element is empty
+    Utf8 "org/openjdk/asmtools/attribute/NestMembers/Test01";  // #1     at 0x0A
+    Class #1;                              // #2     at 0x3D
+    Utf8 "NestMember01";                   // #3     at 0x40
+    Utf8 "org/openjdk/asmtools/attribute/NestMembers/Test01/NestMember01";  // #4     at 0x4F
+    Class #4;                              // #5     at 0x88
+    Utf8 "InnerClasses";                   // #6     at 0x8B
+    Utf8 "NestMembers";                    // #7     at 0x9A
+    Utf8 "Test01.jasm";                    // #8     at 0xA8
+    Utf8 "SourceFile";                     // #9     at 0xB6
+    Utf8 "java/lang/Object";               // #10     at 0xC3
+    Class #10;                             // #11     at 0xD6
+  }                                        // end of Constant Pool
+
+  0x0001;                                  // access [ ACC_PUBLIC ]
+  #2;                                      // this_cpx
+  #11;                                     // super_cpx
+
+  [0] {                                    // Interfaces
+  }                                        // end of Interfaces
+
+  [0] {                                    // Fields
+  }                                        // end of Fields
+
+  [0] {                                    // Methods
+  }                                        // end of Methods
+
+  [3] {                                    // Attributes
+    Attr(#9, 2) {                          // SourceFile at 0xE7
+      #8;
+    }                                      // end of SourceFile
+    ;
+    Attr(#6, 10) {                         // InnerClasses at 0xEF
+      [1] {                                // classes
+           #5    #2    #3   1;             // access [ ACC_PUBLIC ]
+      }
+    }                                      // end of InnerClasses
+    ;
+    Attr(#7, 4) {                          // NestMembers at 0xFF
+      [1] {                                // classes
+        #5;                                // class: org/openjdk/asmtools/attribute/NestMembers/Test01/NestMember01 at 0x0109
+      }
+    }                                      // end of NestMembers
+  }                                        // end of Attributes
+}                                          // end of class org/openjdk/asmtools/attribute/NestMembers/Test01

--- a/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test02.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/NestMembers/Test02.jasm
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package javasoft/sqe/tests/api/java/lang/reflect/RecordComponent;
+
+public final super class Test02 extends java/lang/Record version 69:0
+{
+  private final Field cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;";
+
+  public Method "<init>":"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;)V"
+    stack 2  locals 2
+  {
+         aload_0;
+         invokespecial     Method java/lang/Record."<init>":"()V";
+         aload_0;
+         aload_1;
+         putfield          Field cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;";
+         return;
+  }
+
+  public final Method toString:"()Ljava/lang/String;"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           toString:"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02;)Ljava/lang/String;" {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;"
+                           };
+         areturn;
+  }
+
+  public final Method hashCode:"()I"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           hashCode:"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02;)I" {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;"
+                           };
+         ireturn;
+  }
+
+  public final Method equals:"(Ljava/lang/Object;)Z"
+    stack 2  locals 2
+  {
+         aload_0;
+         aload_1;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           equals:"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02;Ljava/lang/Object;)Z" {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;"
+                           };
+         ireturn;
+  }
+
+  public Method cir:"()Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;"
+    stack 1  locals 1
+  {
+         aload_0;
+         getfield          Field cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;";
+         areturn;
+  }
+
+  SourceFile               "Test02.java";
+
+  Record {
+    Component              cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;";
+  }
+
+  InnerClass               ClassInsideRecord = class Test02$ClassInsideRecord of class Test02;
+  InnerClass               static ClassInsideRecord2 = class Test02$ClassInsideRecord2 of class Test02;
+  InnerClass               static final InnerRecord = class Test02$InnerRecord of class Test02;
+  InnerClass               static abstract InnerInteface = class Test02$ClassInsideRecord2$InnerInteface of class Test02$ClassInsideRecord2;
+  InnerClass               static final InnerInnerRecord = class Test02$InnerRecord$InnerInnerRecord of class Test02$InnerRecord;
+  InnerClass               public static final Lookup = class java/lang/invoke/MethodHandles$Lookup of class java/lang/invoke/MethodHandles;
+
+  NestMembers              Test02$ClassInsideRecord2,
+                           Test02$ClassInsideRecord2$InnerInteface,
+                           Test02$ClassInsideRecord,
+                           Test02$InnerRecord,
+                           Test02$InnerRecord$InnerInnerRecord;
+
+  BootstrapMethod          REF_invokeStatic:java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;";
+                           {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02$ClassInsideRecord;"
+                           }
+} // end Class javasoft/sqe/tests/api/java/lang/reflect/RecordComponent/Test02 compiled from "Test02.java"

--- a/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test01.g.t.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test01.g.t.jasm
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package org/openjdk/asmtools/attribute/PermittedSubclasses;
+
+public super class #3 /* Test01 */ version 62:0
+{
+  const #1   = Methodref   #9.#10;              // java/lang/Object."<init>":"()V"
+  const #2   = Utf8        "org/openjdk/asmtools/attribute/PermittedSubclasses/Test01";
+  const #3   = Class       #2;                  // Test01
+  const #4   = Utf8        "<init>";
+  const #5   = Utf8        "()V";
+  const #6   = Utf8        "Code";
+  const #7   = Utf8        "LineNumberTable";
+  const #8   = Utf8        "java/lang/Object";
+  const #9   = Class       #8;                  // java/lang/Object
+  const #10  = NameAndType #4:#5;               // "<init>":"()V"
+  const #11  = Utf8        "NestMember01";
+  const #12  = Class       #11;                 // NestMember01
+  const #13  = Utf8        "Test01";
+  const #14  = Class       #13;                 // Test01
+  const #15  = Utf8        "InnerClasses";
+  const #16  = Utf8        "NestMember02";
+  const #17  = Class       #16;                 // NestMember02
+  const #18  = Utf8        "NestMember03";
+  const #19  = Class       #18;                 // NestMember03
+  const #20  = Utf8        "NestMember04";
+  const #21  = Class       #20;                 // NestMember04
+  const #22  = Utf8        "SubClass01";
+  const #23  = Utf8        "SubClass02";
+  const #24  = Utf8        "SubClass03";
+  const #25  = Utf8        "SubClass04";
+  const #26  = Utf8        "PermittedSubclasses";
+  const #27  = Class       #22;                 // SubClass01
+  const #28  = Class       #23;                 // SubClass02
+  const #29  = Class       #24;                 // SubClass03
+  const #30  = Class       #25;                 // SubClass04
+  const #31  = Utf8        "NestMembers";
+  const #32  = Utf8        "Test01.jasm";
+  const #33  = Utf8        "SourceFile";
+
+  public Method #4:#5                           // "<init>":"()V"
+    stack 1  locals 1
+  {
+     0:    aload_0;
+     1:    invokespecial     #1;                // Method java/lang/Object."<init>":"()V"
+     4:    return;
+  }
+
+  SourceFile                 #32;               // Test01.jasm
+
+  InnerClasses {
+    public #11 = #12 of #14;                    // NestMember01 = class NestMember01 of class Test01
+    public #16 = #17 of #14;                    // NestMember02 = class NestMember02 of class Test01
+    public #18 = #19 of #14;                    // NestMember03 = class NestMember03 of class Test01
+    public #20 = #21 of #14;                    // NestMember04 = class NestMember04 of class Test01
+  }
+
+  NestMembers                #12,               // NestMember01
+                             #17,               // NestMember02
+                             #19,               // NestMember03
+                             #21;               // NestMember04
+
+  PermittedSubclasses        #27,               // SubClass01
+                             #28,               // SubClass02
+                             #29,               // SubClass03
+                             #30;               // SubClass04
+} // end Class org/openjdk/asmtools/attribute/PermittedSubclasses/Test01 compiled from "Test01.jasm"

--- a/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test01.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test01.jasm
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+super public class org/openjdk/asmtools/attribute/PermittedSubclasses/Test01
+        version 62:0
+{
+  public Method "<init>":"()V"
+        stack 1 locals 1
+  {
+                aload_0;
+                invokespecial   Method java/lang/Object."<init>":"()V";
+                return;
+  }
+
+  InnerClass               public NestMember01 = class NestMember01 of class Test01;
+  InnerClass               public NestMember02 = class NestMember02 of class Test01;
+  InnerClass               public NestMember03 = class NestMember03 of class Test01;
+  InnerClass               public NestMember04 = class NestMember04 of class Test01;
+
+  PermittedSubclasses      SubClass01, SubClass02, SubClass03, SubClass04;
+
+  NestMembers              NestMember01, NestMember02, NestMember03, NestMember04;
+} // end Class Test01

--- a/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test01.jcod
+++ b/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test01.jcod
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+class org/openjdk/asmtools/attribute/PermittedSubclasses/Test01 {
+  0xCAFEBABE;
+  0;                                       // minor version
+  62;                                      // version
+  [15] {                                   // Constant Pool
+    ;                                      // first element is empty
+    Method #8 #9;                          // #1     at 0x0A
+    Utf8 "org/openjdk/asmtools/attribute/PermittedSubclasses/Test01";  // #2     at 0x0F
+    Class #2;                              // #3     at 0x37
+    Utf8 "<init>";                         // #4     at 0x3A
+    Utf8 "()V";                            // #5     at 0x43
+    Utf8 "Code";                           // #6     at 0x49
+    Utf8 "java/lang/Object";               // #7     at 0x50
+    Class #7;                              // #8     at 0x63
+    NameAndType #4 #5;                     // #9     at 0x66
+    Utf8 "org/openjdk/asmtools/attribute/PermittedSubclasses/atr/SubClass01";  // #10     at 0x6B
+    Utf8 "PermittedSubclasses";            // #11     at 0x9B
+    Class #10;                             // #12     at 0xB1
+    Utf8 "Test01.jasm";                    // #13     at 0xB4
+    Utf8 "SourceFile";                     // #14     at 0xC2
+  }                                        // end of Constant Pool
+
+  0x0021;                                  // access [ ACC_PUBLIC, ACC_SUPER ]
+  #3;                                      // this_cpx
+  #8;                                      // super_cpx
+
+  [0] {                                    // Interfaces
+  }                                        // end of Interfaces
+
+  [0] {                                    // Fields
+  }                                        // end of Fields
+
+  [1] {                                    // Methods
+    {                                      // method at 0xDB
+      0x0001;                              // access
+      #4;                                  // name_index       : <init>
+      #5;                                  // descriptor_index : ()V
+      [1] {                                // Attributes
+        Attr(#6, 17) {                     // Code at 0xE3
+          1;                               // max_stack
+          1;                               // max_locals
+          Bytes[5]{
+            0x2A 0xB7 0x00 0x01 0xB1;
+          }
+          [0] {                            // Traps
+          }                                // end of Traps
+          [0] {                            // Attributes
+          }                                // end of Attributes
+        }                                  // end of Code
+      }                                    // end of Attributes
+    }
+  }                                        // end of Methods
+
+  [2] {                                    // Attributes
+    Attr(#14, 2) {                         // SourceFile at 0xFC
+      #13;
+    }                                      // end of SourceFile
+    ;
+    Attr(#11, 4) {                         // PermittedSubclasses at 0x0104
+      [1] {                                // subclasses
+        #12;                               // subclass: org/openjdk/asmtools/attribute/PermittedSubclasses/atr/SubClass01 at 0x010E
+      }
+    }                                      // end of PermittedSubclasses
+  }                                        // end of Attributes
+}                                          // end of class org/openjdk/asmtools/attribute/PermittedSubclasses/Test01

--- a/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test02.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/PermittedSubclasses/Test02.jasm
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+ */
+package javasoft/sqe/tests/api/java/lang/reflect/RecordComponent02;
+
+public final super class Test02 extends java/lang/Record version 69:0
+{
+  private final Field cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;";
+
+  public Method "<init>":"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;)V"
+    stack 2  locals 2
+  {
+         aload_0;
+         invokespecial     Method java/lang/Record."<init>":"()V";
+         aload_0;
+         aload_1;
+         putfield          Field cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;";
+         return;
+  }
+
+  public final Method toString:"()Ljava/lang/String;"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           toString:"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02;)Ljava/lang/String;" {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;"
+                           };
+         areturn;
+  }
+
+  public final Method hashCode:"()I"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           hashCode:"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02;)I" {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;"
+                           };
+         ireturn;
+  }
+
+  public final Method equals:"(Ljava/lang/Object;)Z"
+    stack 2  locals 2
+  {
+         aload_0;
+         aload_1;
+         invokedynamic     InvokeDynamic REF_invokeStatic:Method java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;":
+                           equals:"(Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02;Ljava/lang/Object;)Z" {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;"
+                           };
+         ireturn;
+  }
+
+  public Method cir:"()Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;"
+    stack 1  locals 1
+  {
+         aload_0;
+         getfield          Field cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;";
+         areturn;
+  }
+
+  SourceFile               "Test02.java";
+
+  Record {
+    Component              cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;";
+  }
+
+  InnerClass               ClassInsideRecord = class Test02$ClassInsideRecord of class Test02;
+  InnerClass               static ClassInsideRecord2 = class Test02$ClassInsideRecord2 of class Test02;
+  InnerClass               static final InnerRecord = class Test02$InnerRecord of class Test02;
+  InnerClass               static abstract InnerInteface = class Test02$ClassInsideRecord2$InnerInteface of class Test02$ClassInsideRecord2;
+  InnerClass               static final InnerInnerRecord = class Test02$InnerRecord$InnerInnerRecord of class Test02$InnerRecord;
+  InnerClass               public static final Lookup = class java/lang/invoke/MethodHandles$Lookup of class java/lang/invoke/MethodHandles;
+
+  PermittedSubclasses      Test02$ClassInsideRecord2,
+                           Test02$ClassInsideRecord2$InnerInteface,
+                           Test02$ClassInsideRecord,
+                           Test02$InnerRecord,
+                           Test02$InnerRecord$InnerInnerRecord;
+
+  BootstrapMethod          REF_invokeStatic:java/lang/runtime/ObjectMethods.bootstrap:
+                           "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/TypeDescriptor;Ljava/lang/Class;Ljava/lang/String;[Ljava/lang/invoke/MethodHandle;)Ljava/lang/Object;";
+                           {
+                             class Test02,
+                             String "cir",
+                             MethodHandle REF_getField:Test02.cir:"Ljavasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02$ClassInsideRecord;"
+                           }
+} // end Class javasoft/sqe/tests/api/java/lang/reflect/RecordComponent02/Test02 compiled from "Test02.java"


### PR DESCRIPTION
[CODETOOLS-7904014](https://bugs.openjdk.org/browse/CODETOOLS-7904014): jasm: the jasm incorrectly parses the PermittedSubclasses/NestMembers attribute