### PR TITLE
CODETOOLS-7904032: jasm: Incorrectly processes empty SourceDebugExtension attribute

### DIFF
--- a/src/org/openjdk/asmtools/jasm/JasmEnvironment.java
+++ b/src/org/openjdk/asmtools/jasm/JasmEnvironment.java
@@ -213,7 +213,7 @@ public class JasmEnvironment extends Environment<CompilerLogger> {
                         case 'a', 'b', 'c', 'd', 'e', 'f' -> d = (d << 4) + 10 + ch - 'a';
                         case 'A', 'B', 'C', 'D', 'E', 'F' -> d = (d << 4) + 10 + ch - 'A';
                         default -> {
-                            error(position, "invalid.escape.char");
+                            error(position, "err.invalid.escape.char");
                             return d;
                         }
                     }

--- a/src/org/openjdk/asmtools/jasm/SourceDebugExtensionAttr.java
+++ b/src/org/openjdk/asmtools/jasm/SourceDebugExtensionAttr.java
@@ -61,7 +61,7 @@ public class SourceDebugExtensionAttr extends AttrData {
         return switch (type) {
             case UTF8 -> utf8DebugExtension.isEmpty();
             case BYTE -> byteDebugExtension.isEmpty();
-            default -> throw new RuntimeException("SourceDebugExtension_attribute is not initialized");
+            case NONE -> true; // not initialized
         };
     }
 
@@ -85,7 +85,7 @@ public class SourceDebugExtensionAttr extends AttrData {
         return switch (type) {
             case UTF8 -> utf8DebugExtension.toString().getBytes(UTF_8).length;
             case BYTE -> byteDebugExtension.size();
-            default -> throw new RuntimeException("SourceDebugExtension_attribute is not initialized");
+            case NONE -> 0;
         };
     }
 
@@ -94,7 +94,7 @@ public class SourceDebugExtensionAttr extends AttrData {
         switch (type) {
             case UTF8 -> out.writeBytes(utf8DebugExtension.toString());
             case BYTE -> out.write(toByteArray(byteDebugExtension));
-            default -> throw new RuntimeException("SourceDebugExtension_attribute is not initialized");
+            case  NONE -> out.write(0);
         }
     }
 }

--- a/test/java/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExtensionTests.java
+++ b/test/java/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExtensionTests.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.asmtools.attribute.SourceDebugExtension;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openjdk.asmtools.lib.action.EToolArguments;
+import org.openjdk.asmtools.lib.script.TestScript;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.openjdk.asmtools.lib.utility.StringUtils.funcSubStrCount;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class SourceDebugExtensionTests extends TestScript {
+
+    private static Stream<Arguments> getJasmParameters() {
+        return Stream.of(
+                Arguments.of("SourceDebugExt01.jasm",
+                        EToolArguments.JDIS_G, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        containsString("\"SMAP\\nSourceDebugExt01.java\\nJava\\n*S Java\\n*F\\n+ 1 SourceDebugExt01.java\\n\";"),
+                                        containsString("\"SourceDebugExt01.java\\n*L\\n1#1,5:1\\n*E\";"),
+                                        matchesPattern(".*const #\\d\\d = Utf8 \"SourceDebugExtension\";.*")
+                                )),
+                                (Consumer<String>) (text) ->
+                                        Assertions.assertEquals(2, funcSubStrCount.apply(text, "SourceDebugExtension"))
+                        )
+                ),
+                Arguments.of("SourceDebugExt02.jasm",
+                        EToolArguments.JDIS_G_T, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        containsString("SourceDebugExtension { }"),
+                                        matchesPattern(".*const #\\d\\d = Utf8 \"SourceDebugExtension\";.*")
+                                )),
+                                (Consumer<String>) (text) ->
+                                        Assertions.assertEquals(2, funcSubStrCount.apply(text, "SourceDebugExtension"))
+                        )
+                ),
+                Arguments.of("SourceDebugExt03.jasm",
+                        EToolArguments.JDIS, List.of(
+                                (Consumer<String>) (text) -> assertThat(text, allOf(
+                                        containsString("SourceDebugExtension { 0x01 0x02 0x03 0x04 0x05 0x06 0x07 0x08 0x09 0x0A 0x00 0x0B 0x0C; 0x0D 0x0E 0x0F; }")
+                                )),
+                                (Consumer<String>) (text) ->
+                                        Assertions.assertEquals(1, funcSubStrCount.apply(text, "SourceDebugExtension"))
+                        )
+                )
+        );
+    }
+
+    @BeforeAll
+    public void init() throws IOException {
+        // initialize resource directory
+        super.init("SourceDebugExt01.jasm");
+        // enable warnings for Jasm tests
+        super.enableToolsWarnings();
+    }
+
+    @ParameterizedTest
+    @MethodSource("getJasmParameters")
+    public void jasmTest(String resourceName, EToolArguments args, List<Consumer<String>> tests) {
+        super.jasmTest(resourceName, args, tests);
+    }
+}

--- a/test/java/org/openjdk/asmtools/lib/script/TestScript.java
+++ b/test/java/org/openjdk/asmtools/lib/script/TestScript.java
@@ -1,0 +1,105 @@
+package org.openjdk.asmtools.lib.script;
+
+import org.junit.jupiter.api.Assertions;
+import org.openjdk.asmtools.common.inputs.StringInput;
+import org.openjdk.asmtools.lib.action.*;
+import org.openjdk.asmtools.lib.log.LogAndBinResults;
+import org.openjdk.asmtools.lib.log.LogAndTextResults;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.openjdk.asmtools.lib.utility.StringUtils.funcNormalizeText;
+
+public class TestScript {
+    protected Jasm jasm = new Jasm();
+    private Jcoder jcoder = new Jcoder();
+    protected File resourceDir;
+    protected boolean warningsEnabled = false;
+
+    public void init(String resource) throws IOException {
+        if (resource == null) {
+            throw new IOException("Resource not declared");
+        }
+        URL url = this.getClass().getResource(resource);
+        if (url == null) {
+            fail("Resource \"%s\" not found.".formatted(resource));
+        }
+        this.resourceDir = new File(url.getFile()).getParentFile();
+        if (!this.resourceDir.exists() || !this.resourceDir.isDirectory()) {
+            fail("Resource directory does not exist or is not a directory: " + this.resourceDir);
+        } else if (DebugHelper.isDebug()) {
+            fail("Resource directory initialized: " + this.resourceDir.getAbsolutePath());
+        }
+    }
+
+    public void jasmTest(String resourceName, EToolArguments args, List<Consumer<String>> tests) {
+        // jasm to class in memory
+        // jasm.setDebug(true);
+        LogAndBinResults binResult = jasm.compile(List.of(resourceDir + File.separator + resourceName));
+        // class produced correctly
+        if( !warningsEnabled )
+            Assertions.assertTrue(binResult.log.toString().isEmpty());
+        Assertions.assertEquals(0, binResult.result);
+
+        // class to jasm
+        LogAndTextResults textResult = new Jdis().setArgs(args).decode(binResult.getAsByteInput());
+
+        Assertions.assertEquals(0, textResult.result);
+        String jasmText = textResult.getResultAsString(Function.identity());
+        String normJasmText = funcNormalizeText.apply(jasmText);
+        for (Consumer<String> testConsumer : tests) {
+            testConsumer.accept(normJasmText);
+        }
+        // jasm to class
+        binResult = jasm.compile(new StringInput(jasmText));
+        // class produced correctly
+        Assertions.assertEquals(0, binResult.result);
+        if( !warningsEnabled )
+            Assertions.assertTrue(binResult.log.toString().isEmpty());
+        // class to jasm
+        textResult = new Jdis().setArgs(args).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+        jasmText = textResult.getResultAsString(Function.identity());
+        normJasmText = funcNormalizeText.apply(jasmText);
+        for (Consumer<String> testConsumer : tests) {
+            testConsumer.accept(normJasmText);
+        }
+        // class to jcod
+        textResult = new Jdec().setArgs(EToolArguments.JDEC_G).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+        // jcod to class
+        binResult = jcoder.compile(new StringInput(textResult.getResultAsString(Function.identity())));
+        Assertions.assertEquals(0, binResult.result);
+    }
+
+    public void jcoderTest(String resourceName, EToolArguments args, List<Consumer<String>> tests) {
+        // jcod to class in memory
+        LogAndBinResults binResult = jcoder.compile(List.of(resourceDir + File.separator + resourceName));
+        // class produced correctly
+        Assertions.assertEquals(0, binResult.result);
+        if( !warningsEnabled )
+            Assertions.assertTrue(binResult.log.toString().isEmpty());
+        // class to jcod
+        LogAndTextResults textResult = new Jdec().setArgs(args).decode(binResult.getAsByteInput());
+        String jcoderText = textResult.getResultAsString(funcNormalizeText);
+        Assertions.assertEquals(0, textResult.result);
+        for (Consumer<String> testConsumer : tests) {
+            testConsumer.accept(jcoderText);
+        }
+        // class to jasm twice
+        textResult = new Jdis().setArgs(EToolArguments.JDIS_G_T_LNT_LVT).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+        textResult = new Jdis().setArgs(EToolArguments.JDIS_GG_NC_LNT_LVT).decode(binResult.getAsByteInput());
+        Assertions.assertEquals(0, textResult.result);
+    }
+
+    protected void enableToolsWarnings() {
+        this.warningsEnabled = true;
+    }
+}

--- a/test/resources/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExt01.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExt01.jasm
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ */
+package javasoft/sqe/tests/api/java/lang/classfile/resources/jasm/atr;
+
+public super class SourceDebugExt01 version 66:0
+{
+  public Method "<init>":"()V"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokespecial     Method java/lang/Object."<init>":"()V";
+         return;
+  }
+
+  SourceDebugExtension {
+    "SMAP\nSourceDebugExt01.java\nJava\n*S Java\n*F\n+ 1 SourceDebugExt01.java\nSou";
+    "rceDebugExt01.java\n*L\n1#1,5:1\n*E";
+  }
+} // end Class SourceDebugExt01 compiled from "SourceDebugExt01.java"

--- a/test/resources/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExt02.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExt02.jasm
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
+ */
+package javasoft/sqe/tests/api/java/lang/classfile/resources/jasm/atr;
+
+public super class SourceDebugExt02 version 66:0
+{
+  public Method "<init>":"()V"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokespecial     Method java/lang/Object."<init>":"()V";
+         return;
+  }
+
+  SourceDebugExtension {
+    "";
+  }
+} // end Class SourceDebugExt02 compiled from "SourceDebugExt02.java"

--- a/test/resources/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExt03.jasm
+++ b/test/resources/org/openjdk/asmtools/attribute/SourceDebugExtension/SourceDebugExt03.jasm
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2025; Oracle and/or its affiliates. All rights reserved.
+ */
+package javasoft/sqe/tests/api/java/lang/classfile/resources/jasm/atr;
+
+public super class SourceDebugExt03 version 66:0
+{
+  public Method "<init>":"()V"
+    stack 1  locals 1
+  {
+         aload_0;
+         invokespecial     Method java/lang/Object."<init>":"()V";
+         return;
+  }
+
+  SourceDebugExtension {
+    0x01; 0x02; 0x03; 0x04; 0x05; 0x06; 0x07; 0x08; 0x09; 0x0A; 0x00; 0x0B; 0x0C; 0x0D; 0x0E; 0x0F;
+  }
+} // end Class SourceDebugExt03 compiled from "SourceDebugExt03.java"


### PR DESCRIPTION
[CODETOOLS-7904032](https://bugs.openjdk.org/browse/CODETOOLS-7904032): jasm: Incorrectly processes empty SourceDebugExtension attribute