### PR TITLE
Fix incorrect links in UsingTools.md

### DIFF
--- a/docs/UsingTools.md
+++ b/docs/UsingTools.md
@@ -1,4 +1,3 @@
-## Chapter 1
 ###  Java Assembler Tools (AsmTools) User’s Guide
 
 ---
@@ -19,7 +18,7 @@ The help system describes how to use all the AsmTools components and contains
 the following topics described in this chapter.
 
 -   [Assemblers and Disassemblers](#BADGCIGA)
--   [JASM vs JCOD](chapter2.html#BADGCIGB)
+-   [JASM vs JCOD](#BADGCIGB)
 -   [Tool Usage](#BADCEIIF)
     -  [ASMTools (Launcher)](BADCEABC) 
     -  [JASM](#BADEFIIJ)


### PR DESCRIPTION
Fix incorrect link and header in UsingTools.md

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/asmtools.git pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/asmtools.git pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/asmtools/pull/95.diff">https://git.openjdk.org/asmtools/pull/95.diff</a>

</details>
